### PR TITLE
Unify the two conds generated by case binders and guards

### DIFF
--- a/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
+++ b/src/Language/PureScript/Scheme/CodeGen/Transpiler.hs
@@ -287,6 +287,9 @@ moduleToLibrary (Module _sourceSpan _comments moduleName _path
         --     (cond ((and (eq? (car v) 'Foo) cond1)  result1)
         --           ((and (eq? (car v) 'Foo) cond2)) result2)
         -- TODO: Maybe we should avoid the repeating of the first check.
+        --
+        -- The additional guard parameter is so that we can include the guard
+        -- conditions when handling a guarded expression.
         test :: [(Expr Ann, Binder Ann)] -> Maybe SExpr -> SExpr
         test valueAndBinders maybeGuard = and_ $
           concatMap (\(value, binder) -> binderToTest (exprToScheme value) binder) valueAndBinders

--- a/test/resources/purescript/src/PureScheme/Test/Guard/Take.purs
+++ b/test/resources/purescript/src/PureScheme/Test/Guard/Take.purs
@@ -1,0 +1,14 @@
+module PureScheme.Test.Guard.Take where
+
+import Prelude
+
+data List a = Nil | Cons a (List a)
+
+infixr 6 Cons as :
+
+take :: forall a. Int -> List a -> List a
+take = go Nil
+  where
+  go acc n _ | n < 1 = acc
+  go acc _ Nil = acc
+  go acc n (x : xs) = go (x : acc) (n - 1) xs

--- a/test/resources/scheme/PureScheme.Test.Binder.Guard/lib.sls
+++ b/test/resources/scheme/PureScheme.Test.Binder.Guard/lib.sls
@@ -17,11 +17,8 @@
         (scm:lambda
           (a)
           (scm:cond
-            ((scm:= v 1)
-              (scm:cond
-                ((((Data.Eq.eq Data.Eq.eqInt) a) 2) 3)
-                ((((Data.Eq.eq Data.Eq.eqInt) a) 4) 5)
-                (Data.Boolean.otherwise 6)
-                (scm:else (scm:error #f "Failed pattern match"))))
+            ((scm:and (scm:= v 1) (((Data.Eq.eq Data.Eq.eqInt) a) 2)) 3)
+            ((scm:and (scm:= v 1) (((Data.Eq.eq Data.Eq.eqInt) a) 4)) 5)
+            ((scm:and (scm:= v 1) Data.Boolean.otherwise) 6)
             (scm:else (scm:error #f "Failed pattern match")))))))
   )

--- a/test/resources/scheme/PureScheme.Test.Guard.GCD/lib.sls
+++ b/test/resources/scheme/PureScheme.Test.Guard.GCD/lib.sls
@@ -18,11 +18,8 @@
         (scm:cond
           ((scm:= v1 0) v)
           ((scm:= v 0) v1)
-          (#t
-            (scm:cond
-              ((((Data.Ord.greaterThan Data.Ord.ordInt) v) v1)
-                ((gcd (scm:fx- v v1)) v1))
-              (Data.Boolean.otherwise ((gcd v) (scm:fx- v1 v)))
-              (scm:else (scm:error #f "Failed pattern match"))))
+          ((((Data.Ord.greaterThan Data.Ord.ordInt) v) v1)
+            ((gcd (scm:fx- v v1)) v1))
+          (Data.Boolean.otherwise ((gcd v) (scm:fx- v1 v)))
           (scm:else (scm:error #f "Failed pattern match"))))))
   )

--- a/test/resources/scheme/PureScheme.Test.Guard.Min/lib.sls
+++ b/test/resources/scheme/PureScheme.Test.Guard.Min/lib.sls
@@ -15,10 +15,7 @@
       (scm:lambda
         (m)
         (scm:cond
-          (#t
-            (scm:cond
-              ((scm:fx<? n m) n)
-              (Data.Boolean.otherwise m)
-              (scm:else (scm:error #f "Failed pattern match"))))
+          ((scm:fx<? n m) n)
+          (Data.Boolean.otherwise m)
           (scm:else (scm:error #f "Failed pattern match"))))))
   )

--- a/test/resources/scheme/PureScheme.Test.Guard.Take/lib.sls
+++ b/test/resources/scheme/PureScheme.Test.Guard.Take/lib.sls
@@ -1,0 +1,40 @@
+(library
+  (PureScheme.Test.Guard.Take lib)
+  (export Nil Cons take)
+  (import
+    (prefix (rnrs) scm:)
+    (prefix (Data.Ord lib) Data.Ord.)
+    (prefix (Data.Ring lib) Data.Ring.)
+    (prefix (Prelude lib) Prelude.))
+
+
+  (scm:define Nil (scm:cons (scm:quote Nil) (scm:vector)))
+
+  (scm:define
+    Cons
+    (scm:lambda
+      (value0)
+      (scm:lambda
+        (value1)
+        (scm:cons (scm:quote Cons) (scm:vector value0 value1)))))
+
+  (scm:define
+    take
+    (scm:letrec*
+      ((go
+        (scm:lambda
+          (acc)
+          (scm:lambda
+            (v)
+            (scm:lambda
+              (v1)
+              (scm:cond
+                ((scm:fx<? v 1) acc)
+                ((scm:eq? (scm:car v1) (scm:quote Nil)) acc)
+                ((scm:eq? (scm:car v1) (scm:quote Cons))
+                  (((go ((Cons (scm:vector-ref (scm:cdr v1) 0)) acc))
+                      (scm:fx- v 1))
+                    (scm:vector-ref (scm:cdr v1) 1)))
+                (scm:else (scm:error #f "Failed pattern match"))))))))
+      (go Nil)))
+  )


### PR DESCRIPTION
Fix #63 as per title. Since there can be multiple guards for each condition branch of a `case`, we duplicate them when merging the conditions. This can be seen in action in the `PureScheme.Test.Binder.Guard` test.

We include the failing example from #63 as a test here, and it now reads correct:
```scheme
  (scm:define
    take
    (scm:letrec*
      ((go
        (scm:lambda (acc)
          (scm:lambda (v)
            (scm:lambda (v1)
              (scm:cond
                ((scm:fx<? v 1) acc)
                ((scm:eq? (scm:car v1) (scm:quote Nil)) acc)
                ((scm:eq? (scm:car v1) (scm:quote Cons))
                  (((go ((Cons (scm:vector-ref (scm:cdr v1) 0)) acc))
                      (scm:fx- v 1))
                    (scm:vector-ref (scm:cdr v1) 1)))
                (scm:else (scm:error #f "Failed pattern match"))))))))
      (go Nil)))
```