### PR TITLE
Refactor syntax towards spec; pretty-print things

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -2,43 +2,12 @@ module Main where
 
 import Prelude
 
-import Control.Alternative (empty)
-import Data.Argonaut as Json
-import Data.Bifunctor (lmap)
-import Data.Either (Either(..))
-import Dodo (plainText)
-import Dodo as Dodo
 import Effect (Effect)
-import Effect.Aff (Aff, launchAff_)
-import Effect.Class.Console (error, log)
-import PureScript.Backend.Chez.Convert (codegenModule)
-import PureScript.Backend.Chez.Syntax as S
-import PureScript.Backend.Optimizer.Builder (buildModules)
-import PureScript.Backend.Optimizer.CoreFn (Ann, Module)
-import PureScript.Backend.Optimizer.CoreFn.Json (decodeModule)
-
-simpleCoreFn :: String
-simpleCoreFn =
-  """
-{"builtWith":"0.15.8","comments":[],"decls":[{"annotation":{"meta":null,"sourceSpan":{"end":[9,12],"start":[5,1]}},"bindType":"NonRec","expression":{"annotation":{"meta":null,"sourceSpan":{"end":[9,12],"start":[6,3]}},"binds":[{"annotation":{"meta":null,"sourceSpan":{"end":[7,18],"start":[7,5]}},"bindType":"NonRec","expression":{"abstraction":{"abstraction":{"annotation":{"meta":{"metaType":"IsForeign"},"sourceSpan":{"end":[7,12],"start":[7,9]}},"type":"Var","value":{"identifier":"add","moduleName":["Simple"]}},"annotation":{"meta":null,"sourceSpan":{"end":[7,15],"start":[7,9]}},"argument":{"annotation":{"meta":null,"sourceSpan":{"end":[7,15],"start":[7,13]}},"type":"Literal","value":{"literalType":"IntLiteral","value":42}},"type":"App"},"annotation":{"meta":null,"sourceSpan":{"end":[7,18],"start":[7,9]}},"argument":{"annotation":{"meta":null,"sourceSpan":{"end":[7,18],"start":[7,16]}},"type":"Literal","value":{"literalType":"IntLiteral","value":42}},"type":"App"},"identifier":"a"}],"expression":{"abstraction":{"abstraction":{"annotation":{"meta":{"metaType":"IsForeign"},"sourceSpan":{"end":[9,8],"start":[9,5]}},"type":"Var","value":{"identifier":"add","moduleName":["Simple"]}},"annotation":{"meta":null,"sourceSpan":{"end":[9,10],"start":[9,5]}},"argument":{"annotation":{"meta":null,"sourceSpan":{"end":[9,10],"start":[9,9]}},"type":"Var","value":{"identifier":"a","sourcePos":[7,5]}},"type":"App"},"annotation":{"meta":null,"sourceSpan":{"end":[9,12],"start":[9,5]}},"argument":{"annotation":{"meta":null,"sourceSpan":{"end":[9,12],"start":[9,11]}},"type":"Var","value":{"identifier":"a","sourcePos":[7,5]}},"type":"App"},"type":"Let"},"identifier":"notBasic"}],"exports":["add","notBasic"],"foreign":["add"],"imports":[{"annotation":{"meta":null,"sourceSpan":{"end":[9,12],"start":[1,1]}},"moduleName":["Prim"]},{"annotation":{"meta":null,"sourceSpan":{"end":[9,12],"start":[1,1]}},"moduleName":["Simple"]}],"moduleName":["Simple"],"modulePath":"src/Simple.purs","reExports":{},"sourceSpan":{"end":[9,12],"start":[1,1]}}
-"""
-
-parseCoreFnModule :: String -> Aff (Either String (Module Ann))
-parseCoreFnModule contents = pure $ lmap Json.printJsonDecodeError <<< decodeModule =<<
-  Json.jsonParser contents
+import Effect.Aff (launchAff_)
+import Effect.Class (liftEffect)
+import Effect.Console (log)
 
 main :: Effect Unit
 main = launchAff_ do
-  coreFnModule <- parseCoreFnModule simpleCoreFn
-  case coreFnModule of
-    Left e -> error e
-    Right m -> do
-      pure m # buildModules
-        { directives: empty
-        , foreignSemantics: empty
-        , onCodegenModule: \_ _ backendModule -> do
-            log $ Dodo.print plainText Dodo.twoSpaces $ S.printChezExpr $ codegenModule
-              backendModule
-            pure unit
-        , onPrepareModule: \_ coreFnM -> pure coreFnM
-        }
+  liftEffect $ log "Not yet implemented. See tests."
+  pure unit

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -4,13 +4,13 @@ import Prelude
 
 import Data.Argonaut as Json
 import Data.Array as Array
+import Data.Array.NonEmpty as NEA
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Maybe (Maybe(..))
-import Data.Newtype (wrap)
-import Data.Profunctor.Strong (second)
+import Data.Newtype (un, unwrap, wrap)
 import Data.String.CodeUnits as CodeUnits
-import Data.Tuple (Tuple, uncurry)
-import PureScript.Backend.Chez.Syntax (ChezExpr)
+import Data.Tuple (Tuple(..), uncurry)
+import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezExpr, ChezImport(..), ChezImportSet(..), ChezLibrary)
 import PureScript.Backend.Chez.Syntax as S
 import PureScript.Backend.Optimizer.Convert (BackendModule, BackendBindingGroup)
 import PureScript.Backend.Optimizer.CoreFn (Ident(..), Literal(..), ModuleName(..), Qualified(..))
@@ -22,29 +22,106 @@ type CodegenEnv =
   { currentModule :: ModuleName
   }
 
-codegenModule :: BackendModule -> ChezExpr
+codegenModule :: BackendModule -> ChezLibrary
 codegenModule { name, bindings, exports } =
   let
     codegenEnv :: CodegenEnv
     codegenEnv = { currentModule: name }
 
-    exports' :: Array Ident
-    exports' = Array.fromFoldable exports
+    exports' :: Array ChezExport
+    exports' = map ExportIdentifier $ coerce $ Array.fromFoldable exports
 
-    bindings' :: Array ChezExpr
-    bindings' = Array.concat $ codegenTopLevelBindingGroup codegenEnv <$> bindings
+    definitions :: Array ChezDefinition
+    definitions = Array.concat $
+      codegenTopLevelBindingGroup codegenEnv <$> bindings
   in
-    S.library name exports' bindings'
+    { "#!r6rs": true
+    , "#!chezscheme": true
+    , name:
+        { identifiers: NEA.cons' (coerce name) [ "lib" ]
+        , version: []
+        }
+    , imports:
+        [ ImportSet $ ImportPrefix
+            (ImportLibrary { identifiers: NEA.singleton "chezscheme", version: Nothing })
+            "scm:"
+        ]
+    , exports: exports'
+    , body: { definitions, exprs: [] }
+    }
 
-codegenTopLevelBindingGroup :: CodegenEnv -> BackendBindingGroup Ident NeutralExpr -> Array ChezExpr
+codegenTopLevelBindingGroup
+  :: CodegenEnv -> BackendBindingGroup Ident NeutralExpr -> Array ChezDefinition
 codegenTopLevelBindingGroup codegenEnv { recursive, bindings }
   | recursive, Just bindings' <- NonEmptyArray.fromArray bindings =
-      [ S.Identifier "recursive-top-level-binding-group" ]
-  | otherwise = codegenBindings codegenEnv bindings
+      [ DefineValue "rtlbg" $ S.Identifier "recursive-top-level-binding-group" ]
+  | otherwise =
+      map (codegenTopLevelBinding codegenEnv) bindings
 
-codegenBindings :: CodegenEnv -> Array (Tuple Ident NeutralExpr) -> Array ChezExpr
-codegenBindings codegenEnv = map (coerce $ uncurry S.define) <<< map
-  (second $ codegenExpr codegenEnv)
+codegenTopLevelBinding :: CodegenEnv -> Tuple Ident NeutralExpr -> ChezDefinition
+codegenTopLevelBinding codegenEnv@{ currentModule } (Tuple (Ident ident) expr) = case unwrap expr of
+  Var (Qualified (Just moduleName) (Ident v))
+    | currentModule == moduleName -> DefineValue ident $ S.Identifier v
+    | otherwise -> DefineValue ident $ S.Identifier $ coerce moduleName <> "." <> v
+  Var (Qualified Nothing (Ident v)) ->
+    DefineValue ident $ S.Identifier v
+  Local i l ->
+    DefineValue ident $ S.Identifier $ coerce $ S.toChezIdent i l
+  Lit l ->
+    DefineValue ident $ codegenLiteral codegenEnv l
+  App f p ->
+    DefineValue ident $ S.chezCurriedApplication (codegenExpr codegenEnv f)
+      (codegenExpr codegenEnv <$> p)
+  Abs a e -> do
+    DefineCurriedFunction
+      ident
+      (map (un Ident <<< uncurry S.toChezIdent) $ a)
+      (codegenExpr codegenEnv e)
+
+  UncurriedApp _ _ ->
+    DefineValue ident $ S.Identifier "uncurried-app"
+  UncurriedAbs _ _ ->
+    DefineValue ident $ S.Identifier "uncurried-abs"
+
+  UncurriedEffectApp _ _ ->
+    DefineValue ident $ S.Identifier "uncurried-effect-app"
+  UncurriedEffectAbs _ _ ->
+    DefineValue ident $ S.Identifier "uncurried-effect-ab"
+
+  Accessor _ _ ->
+    DefineValue ident $ S.Identifier "object-accessor"
+  Update _ _ ->
+    DefineValue ident $ S.Identifier "object-update"
+
+  CtorSaturated _ _ _ _ _ ->
+    DefineValue ident $ S.Identifier "ctor-saturated"
+  CtorDef _ _ _ _ ->
+    DefineValue ident $ S.Identifier "ctor-def"
+
+  LetRec _ _ _ ->
+    DefineValue ident $ S.Identifier "let-rec"
+  Let i l v e ->
+    DefineValue ident $ S.chezLet (S.toChezIdent i l) (codegenExpr codegenEnv v)
+      (codegenExpr codegenEnv e)
+  Branch _ _ ->
+    DefineValue ident $ S.Identifier "branch"
+
+  EffectBind _ _ _ _ ->
+    DefineValue ident $ S.Identifier "effect-bind"
+  EffectPure _ ->
+    DefineValue ident $ S.Identifier "effect-pure"
+  EffectDefer _ ->
+    DefineValue ident $ S.Identifier "effect-defer"
+
+  PrimOp _ ->
+    DefineValue ident $ S.Identifier "prim-op"
+  PrimEffect _ ->
+    DefineValue ident $ S.Identifier "prim-effect"
+  PrimUndefined ->
+    DefineValue ident $ S.Identifier "prim-undefined"
+
+  Fail _ ->
+    DefineValue ident $ S.Identifier "fail"
 
 codegenExpr :: CodegenEnv -> NeutralExpr -> ChezExpr
 codegenExpr codegenEnv@{ currentModule } (NeutralExpr s) = case s of

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -2,17 +2,87 @@ module PureScript.Backend.Chez.Syntax where
 
 import Prelude
 
+import Control.Alternative as Alternative
 import Data.Argonaut as Json
 import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray)
+import Data.Array.NonEmpty as NEA
 import Data.Array.NonEmpty as NonEmptyArray
-import Data.Maybe (Maybe(..))
-import Data.Newtype (class Newtype)
-import Dodo as Dodo
+import Data.Maybe (Maybe(..), maybe)
+import Data.Newtype (class Newtype, un)
+import Dodo (Doc)
+import Dodo as D
 import Prim as Prim
 import PureScript.Backend.Optimizer.CoreFn (Ident(..), ModuleName(..), Prop(..))
 import PureScript.Backend.Optimizer.Syntax (Level(..))
 import Safe.Coerce (coerce)
+
+type ChezLibrary =
+  { "#!r6rs" :: Prim.Boolean
+  , "#!chezscheme" :: Prim.Boolean
+  , name :: LibraryName
+  , exports :: Prim.Array ChezExport
+  , imports :: Prim.Array ChezImport
+  , body :: LibraryBody
+  }
+
+type LibraryName =
+  { identifiers :: NonEmptyArray Prim.String
+  , version :: Prim.Array LibraryVersion
+  }
+
+newtype LibraryVersion = LibraryVersion Prim.Int
+
+derive instance Newtype LibraryVersion _
+
+data ChezExport
+  = ExportIdentifier Prim.String
+  | ExportRename (Prim.Array { original :: Prim.String, rename :: Prim.String })
+
+type LibraryReference =
+  { identifiers :: NonEmptyArray Prim.String
+  , version :: Maybe VersionReference
+  }
+
+data VersionReference
+  = VersionRef (NonEmptyArray SubVersionReference)
+  | VersionAnd (Prim.Array VersionReference)
+  | VersionOr (Prim.Array VersionReference)
+  | VersionNot VersionReference
+
+data SubVersionReference
+  = SubVersionRef LibraryVersion
+  | SubVersionGTE LibraryVersion
+  | SubVersionLTE LibraryVersion
+  | SubVersionAnd (Prim.Array SubVersionReference)
+  | SubVersionOr (Prim.Array SubVersionReference)
+  | SubVersionNot SubVersionReference
+
+data ChezImport
+  = ImportSet ChezImportSet
+  | ImportFor ChezImportSet (Prim.Array ChezImportLevel)
+
+data ChezImportLevel
+  = ImportLevelRun
+  | ImportLevelExpand
+  | ImportLevelMeta Prim.Int
+
+data ChezImportSet
+  = ImportLibrary LibraryReference
+  | ImportOnly ChezImportSet (Prim.Array Prim.String)
+  | ImportExcept ChezImportSet (Prim.Array Prim.String)
+  | ImportPrefix ChezImportSet Prim.String
+  | ImportRename ChezImportSet (Prim.Array { original :: Prim.String, rename :: Prim.String })
+
+type LibraryBody =
+  { definitions :: Prim.Array ChezDefinition
+  , exprs :: Prim.Array ChezExpr
+  }
+
+data ChezDefinition
+  = DefineValue Prim.String ChezExpr
+  | DefineCurriedFunction Prim.String (NonEmptyArray Prim.String) ChezExpr
+  | DefineUncurriedFunction Prim.String (NonEmptyArray Prim.String) ChezExpr
 
 newtype LiteralDigit = LiteralDigit Prim.String
 
@@ -28,14 +98,187 @@ data ChezExpr
   | Identifier Prim.String
   | List (Prim.Array ChezExpr)
 
-printChezExpr :: forall a. ChezExpr -> Dodo.Doc a
+printWrap :: Doc Void -> Doc Void -> Doc Void -> Doc Void
+printWrap l r x = l <> x <> r
+
+printList :: Doc Void -> Doc Void
+printList = printWrap (D.text "(") (D.text ")")
+
+printNamedList :: Prim.String -> Doc Void -> Doc Void
+printNamedList name body
+  | D.isEmpty body =
+      printList $ D.text name
+  | otherwise =
+      printList $ D.words [ D.text name, body ]
+
+printIndentedList :: Doc Void -> Doc Void -> Doc Void
+printIndentedList ident body
+  | D.isEmpty body =
+      printList ident
+  | otherwise =
+      D.lines
+        [ D.text "(" <> ident
+        , D.indent body <> D.text ")"
+        ]
+
+linesSeparated :: Prim.Array (Doc Void) -> Doc Void
+linesSeparated = Array.intercalate twoLineBreaks
+  where
+  twoLineBreaks = D.break <> D.break
+
+printLibrary :: ChezLibrary -> Doc Void
+printLibrary lib =
+  flip append D.break
+    $ D.lines
+    $ Array.catMaybes
+        [ D.text "#!r6rs" <$ Alternative.guard lib."#!r6rs"
+        , D.text "#!chezscheme" <$ Alternative.guard lib."#!chezscheme"
+        , Just $ printNamedIndentedList (D.text "library") $ D.lines
+            [ printLibraryName lib.name
+            , printIndentedList (D.text "export") $ D.lines $ map printExport lib.exports
+            , (printIndentedList (D.text "import") $ D.lines $ map printImport lib.imports)
+                <> D.break
+            , printBody lib.body
+            ]
+        ]
+
+printLibraryName :: LibraryName -> Doc Void
+printLibraryName { identifiers, version } =
+  printList $ D.words
+    [ D.words $ map D.text identifiers
+    , case version of
+        [] -> mempty
+        _ -> printList $ D.words $ map printLibraryVersion version
+    ]
+
+printLibraryVersion :: LibraryVersion -> Doc Void
+printLibraryVersion = D.text <<< show <<< un LibraryVersion
+
+printExport :: ChezExport -> Doc Void
+printExport = case _ of
+  ExportIdentifier s -> D.text s
+  ExportRename arr ->
+    printNamedList "rename"
+      $ D.words
+      $ map (\r -> printList $ D.words [ D.text r.original, D.text r.rename ]) arr
+
+printImport :: ChezImport -> Doc Void
+printImport = case _ of
+  ImportSet is -> printImportSet is
+  ImportFor is lvls ->
+    printNamedList "for" $ D.words
+      [ printImportSet is
+      , D.words $ map printImportLevel lvls
+      ]
+
+printImportLevel :: ChezImportLevel -> Doc Void
+printImportLevel = case _ of
+  ImportLevelRun -> D.text "run"
+  ImportLevelExpand -> D.text "expand"
+  ImportLevelMeta level -> printNamedList "meta" $ D.text $ show level
+
+printImportSet :: ChezImportSet -> Doc Void
+printImportSet = case _ of
+  ImportLibrary libRef ->
+    printLibraryReference libRef
+  ImportOnly impSet identifiers ->
+    printNamedList "only" $ D.words
+      [ printImportSet impSet, D.words $ map D.text identifiers ]
+  ImportExcept impSet identifiers ->
+    printNamedList "except" $ D.words
+      [ printImportSet impSet, D.words $ map D.text identifiers ]
+  ImportPrefix impSet rename ->
+    printNamedList "prefix" $ D.words [ printImportSet impSet, D.text rename ]
+  ImportRename impSet identifiers ->
+    printNamedList "rename" $ D.words
+      [ printImportSet impSet
+      , D.words $ map (\r -> printList $ D.words $ map D.text [ r.original, r.rename ])
+          identifiers
+      ]
+
+printLibraryReference :: LibraryReference -> Doc Void
+printLibraryReference lib = do
+  let
+    printListFn
+      | Array.elem (NEA.head lib.identifiers)
+          [ "for", "library", "only", "except", "prefix", "rename" ] =
+          printNamedList "library"
+      | otherwise =
+          printList
+  printListFn $ D.words
+    [ D.words $ map D.text lib.identifiers
+    , maybe mempty printVersionReference lib.version
+    ]
+
+printVersionReference :: VersionReference -> Doc Void
+printVersionReference = case _ of
+  VersionRef ref ->
+    printList $ D.words $ map printSubVersionReference ref
+  VersionAnd ref ->
+    printNamedList "and" $ D.words $ map printVersionReference ref
+  VersionOr ref ->
+    printNamedList "or" $ D.words $ map printVersionReference ref
+  VersionNot ref ->
+    printNamedList "not" $ printVersionReference ref
+
+printSubVersionReference :: SubVersionReference -> Doc Void
+printSubVersionReference = case _ of
+  SubVersionRef ref -> printList $ printLibraryVersion ref
+  SubVersionGTE ref -> printNamedList ">=" $ printLibraryVersion ref
+  SubVersionLTE ref -> printNamedList "<=" $ printLibraryVersion ref
+  SubVersionAnd ref -> printNamedList "and" $ D.words
+    $ map printSubVersionReference ref
+  SubVersionOr ref -> printNamedList "or" $ D.words
+    $ map printSubVersionReference ref
+  SubVersionNot ref -> printNamedList "not" $ printSubVersionReference ref
+
+printBody :: LibraryBody -> Doc Void
+printBody lib = do
+  let
+    defs = map printDefinition lib.definitions
+    exprs = map printChezExpr lib.exprs
+  linesSeparated $ defs <> exprs
+
+printNamedIndentedList :: Doc Void -> Doc Void -> Doc Void
+printNamedIndentedList firstLine body
+  | D.isEmpty body =
+      printList firstLine
+  | otherwise =
+      D.lines
+        [ D.text "(" <> firstLine
+        , D.indent $ body <> D.text ")"
+        ]
+
+printDefinition :: ChezDefinition -> Doc Void
+printDefinition = case _ of
+  DefineValue ident expr ->
+    printNamedIndentedList (D.words [ D.text "scm:define", D.text ident ])
+      $ printChezExpr expr
+  DefineCurriedFunction ident args expr ->
+    printNamedIndentedList (D.text "scm:define " <> D.text ident)
+      $ printCurriedApp (NEA.toArray args) expr
+  DefineUncurriedFunction ident args expr ->
+    printNamedIndentedList (D.text "scm:define" <> D.text ident)
+      $ printNamedIndentedList
+          (D.text "scm:lambda " <> printList (D.words $ map D.text args))
+          (printChezExpr expr)
+
+printCurriedApp :: Prim.Array Prim.String -> ChezExpr -> Doc Void
+printCurriedApp args body = case Array.uncons args of
+  Nothing -> printChezExpr body
+  Just { head, tail } ->
+    printNamedIndentedList
+      (D.text "scm:lambda " <> printList (D.text head))
+      (printCurriedApp tail body)
+
+printChezExpr :: forall a. ChezExpr -> Doc a
 printChezExpr e = case e of
-  Integer (LiteralDigit x) -> Dodo.text x
-  Float (LiteralDigit x) -> Dodo.text x
-  String x -> Dodo.text x
-  Boolean x -> Dodo.text $ if x then "#t" else "#f"
-  Identifier x -> Dodo.text x
-  List xs -> Dodo.text "(" <> Dodo.words (printChezExpr <$> xs) <> Dodo.text ")"
+  Integer (LiteralDigit x) -> D.text x
+  Float (LiteralDigit x) -> D.text x
+  String x -> D.text x
+  Boolean x -> D.text $ if x then "#t" else "#f"
+  Identifier x -> D.text x
+  List xs -> D.text "(" <> D.words (printChezExpr <$> xs) <> D.text ")"
 
 toChezIdent :: Maybe Ident -> Level -> Ident
 toChezIdent i (Level l) = Ident $ case i of

--- a/test-snapshots/snapshots-output/Snapshot.Function.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Function.ss
@@ -1,1 +1,19 @@
-(library (Snapshot.Function lib) (export f g) (import (prefix (chezscheme) scm:)) (scm:define f (scm:lambda (x0) (scm:lambda (y1) (scm:vector x0 y1 x0 y1 x0)))) (scm:define g (scm:lambda (x0) (scm:lambda (y1) ((f x0) y1)))))
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Function lib)
+  (export
+    f
+    g)
+  (import
+    (prefix (chezscheme) scm:))
+
+  (scm:define f
+    (scm:lambda (x0)
+      (scm:lambda (y1)
+        (scm:vector x0 y1 x0 y1 x0))))
+
+  (scm:define g
+    (scm:lambda (x0)
+      (scm:lambda (y1)
+        ((f x0) y1)))))

--- a/test-snapshots/snapshots-output/Snapshot.Literals.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Literals.ss
@@ -1,1 +1,47 @@
-(library (Snapshot.Literals lib) (export array array2 boolean1 boolean2 char int number record record2 string) (import (prefix (chezscheme) scm:)) (scm:define string "string") (scm:define record2 (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) (scm:hashtable-set! $record "foo" "bar") $record)) (scm:define record (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) $record)) (scm:define number 2.0) (scm:define int 1) (scm:define char #\a) (scm:define boolean2 #f) (scm:define boolean1 #t) (scm:define array2 (scm:vector 1 2 3)) (scm:define array (scm:vector)))
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Literals lib)
+  (export
+    array
+    array2
+    boolean1
+    boolean2
+    char
+    int
+    number
+    record
+    record2
+    string)
+  (import
+    (prefix (chezscheme) scm:))
+
+  (scm:define string
+    "string")
+
+  (scm:define record2
+    (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) (scm:hashtable-set! $record "foo" "bar") $record))
+
+  (scm:define record
+    (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) $record))
+
+  (scm:define number
+    2.0)
+
+  (scm:define int
+    1)
+
+  (scm:define char
+    #\a)
+
+  (scm:define boolean2
+    #f)
+
+  (scm:define boolean1
+    #t)
+
+  (scm:define array2
+    (scm:vector 1 2 3))
+
+  (scm:define array
+    (scm:vector)))

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -107,8 +107,7 @@ runSnapshotTests { accept, filter } = do
             let
               formatted =
                 Dodo.print plainText Dodo.twoSpaces
-                  $ flip append Dodo.break
-                  $ S.printChezExpr
+                  $ S.printLibrary
                   $ codegenModule backend
             let testFileDir = Path.concat [ testOut, name ]
             let testFilePath = Path.concat [ testFileDir, "output.ss" ]


### PR DESCRIPTION
Begins to address #74

I'm following the spec I summarized in https://github.com/JordanMartinez/purs-backend-cs/blob/master/chez-scheme-eBNF.md

I haven't fully implemented the types for the `expr`, but this is at least a better start than what we had.

I haven't removed the other code PureFunctor wrote in case we want to reuse parts of that.