### PR TITLE
Implement Branch, PrimOp, and Fail; add runtime module

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -11,6 +11,7 @@
   , "dodo-printer"
   , "effect"
   , "either"
+  , "foldable-traversable"
   , "maybe"
   , "newtype"
   , "ordered-collections"
@@ -19,6 +20,7 @@
   , "profunctor"
   , "safe-coerce"
   , "strings"
+  , "transformers"
   , "tuples"
   ]
 , packages = ./packages.dhall

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -151,6 +151,9 @@ codegenExpr codegenEnv@{ currentModule } (NeutralExpr s) = case s of
     S.Identifier "prim-undefined"
 
   Fail i ->
+    -- Note: This can be improved by using `error`, but it requires
+    -- that we track where exactly this `Fail` is defined. We can
+    -- make use of the `codegenEnv` for this.
     S.List
       [ S.Identifier "scm:raise"
       , S.List

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -150,8 +150,18 @@ codegenExpr codegenEnv@{ currentModule } (NeutralExpr s) = case s of
   PrimUndefined ->
     S.Identifier "prim-undefined"
 
-  Fail _ ->
-    S.Identifier "fail"
+  Fail i ->
+    S.List
+      [ S.Identifier "scm:raise"
+      , S.List
+          [ S.Identifier "scm:condition"
+          , S.List [ S.Identifier "scm:make-error" ]
+          , S.List
+              [ S.Identifier "scm:make-message-condition"
+              , S.String $ Json.stringify $ Json.fromString i
+              ]
+          ]
+      ]
 
 codegenLiteral :: CodegenEnv -> Literal NeutralExpr -> ChezExpr
 codegenLiteral codegenEnv = case _ of

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -182,8 +182,54 @@ codegenPrimOp codegenEnv = case _ of
         OpGte -> S.Identifier "scm:>="
         OpLt -> S.Identifier "scm:<"
         OpLte -> S.Identifier "scm:<="
+
+      opCharOrd = case _ of
+        OpEq -> S.Identifier "scm:char=?"
+        OpNotEq -> S.Identifier "scm:char=?"
+        OpGt -> S.Identifier "scm:char>?"
+        OpGte -> S.Identifier "scm:char>=?"
+        OpLt -> S.Identifier "scm:char<?"
+        OpLte -> S.Identifier "scm:char<=?"
+
+      opStringOrd = case _ of
+        OpEq -> S.Identifier "scm:string=?"
+        OpNotEq -> S.Identifier "scm:string=?"
+        OpGt -> S.Identifier "scm:string>?"
+        OpGte -> S.Identifier "scm:string>=?"
+        OpLt -> S.Identifier "scm:string<?"
+        OpLte -> S.Identifier "scm:string<=?"
     in
       case o of
+        OpArrayIndex ->
+          S.List [ S.Identifier "scm:vector-ref", x', y' ]
+        OpBooleanAnd ->
+          S.List [ S.Identifier "scm:and", x', y' ]
+        OpBooleanOr ->
+          S.List [ S.Identifier "scm:or", x', y' ]
+        OpBooleanOrd _ ->
+          -- Neither R6RS nor Chez defines comparison operators for
+          -- booleans, meaning that we would either have to inject
+          -- the definitions at the call site _or_ provide them
+          -- through a library loaded by _all_ files.
+          S.Identifier "boolean-ord"
+        OpCharOrd o' ->
+          case o' of
+            OpNotEq ->
+              S.List [ S.Identifier "scm:not", S.List [ opCharOrd o', x', y' ] ]
+            _ ->
+              S.List [ opCharOrd o', x', y' ]
+        OpIntBitAnd ->
+          S.List [ S.Identifier "scm:bitwise-and", x', y' ]
+        OpIntBitOr ->
+          S.List  [ S.Identifier "scm:bitwise-or", x', y' ]
+        OpIntBitShiftLeft ->
+          S.List [ S.Identifier "scm:bitwise-arithmetic-shift-left", x', y' ]
+        OpIntBitShiftRight ->
+          S.List [ S.Identifier "scm:bitwise-arithmetic-shift-right", x', y' ]
+        OpIntBitXor ->
+          S.List [ S.Identifier "scm:bitwise-xor", x', y' ]
+        OpIntBitZeroFillShiftRight ->
+          S.Identifier "zero-fill-shift-right"
         OpIntNum o' ->
           S.List [ opDtNum o', x', y' ]
         OpIntOrd o' ->
@@ -200,5 +246,13 @@ codegenPrimOp codegenEnv = case _ of
               S.List [ S.Identifier "scm:not", S.List [ opDtOrd o', x', y' ] ]
             _ ->
               S.List [ opDtOrd o', x', y' ]
-        _ ->
-          S.Identifier "binary-prim-op"
+        OpStringAppend ->
+          S.List [ S.Identifier "scm:string-append", x', y' ]
+        OpStringOrd o' ->
+          -- We've done this pattern-matching four times. Should this
+          -- be refactored to have the pretty-printer deal with it?
+          case o' of
+            OpNotEq ->
+              S.List [ S.Identifier "scm:not", S.List [ opStringOrd o', x', y' ] ]
+            _ -> 
+              S.List [ opStringOrd o', x', y' ]

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -63,6 +63,9 @@ codegenModule { name, bindings, exports, imports, foreign: foreign_ } =
         [ ImportSet $ ImportPrefix
             (ImportLibrary { identifiers: NEA.singleton "chezscheme", version: Nothing })
             "scm:"
+        , ImportSet $ ImportPrefix
+            (ImportLibrary { identifiers: NEA.cons' "_Chez_Runtime" [ "lib" ], version: Nothing })
+            "rt:"
         ] <> pursImports <> foreignImport
     , exports: exports'
     , body: { definitions, expressions: [] }
@@ -198,7 +201,7 @@ codegenPrimOp codegenEnv = case _ of
         OpLt -> S.Identifier "scm:fx<"
         OpLte -> S.Identifier "scm:fx<="
 
-      opFloNum = case _ of 
+      opFloNum = case _ of
         OpAdd -> S.Identifier "scm:fl+"
         OpSubtract -> S.Identifier "scm:fl-"
         OpMultiply -> S.Identifier "scm:fl*"

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -169,19 +169,33 @@ codegenPrimOp codegenEnv = case _ of
       x' = codegenExpr codegenEnv x
       y' = codegenExpr codegenEnv y
 
-      opDtNum = case _ of
-        OpAdd -> S.Identifier "scm:+"
-        OpSubtract -> S.Identifier "scm:-"
-        OpMultiply -> S.Identifier "scm:*"
-        OpDivide -> S.Identifier "scm:/"
+      opFixNum = case _ of
+        OpAdd -> S.Identifier "scm:fx+"
+        OpSubtract -> S.Identifier "scm:fx-"
+        OpMultiply -> S.Identifier "scm:fx*"
+        OpDivide -> S.Identifier "scm:fx/"
 
-      opDtOrd = case _ of
-        OpEq -> S.Identifier "scm:="
-        OpNotEq -> S.Identifier "scm:="
-        OpGt -> S.Identifier "scm:>"
-        OpGte -> S.Identifier "scm:>="
-        OpLt -> S.Identifier "scm:<"
-        OpLte -> S.Identifier "scm:<="
+      opFixOrd = case _ of
+        OpEq -> S.Identifier "scm:fx="
+        OpNotEq -> S.Identifier "scm:fx="
+        OpGt -> S.Identifier "scm:fx>"
+        OpGte -> S.Identifier "scm:fx>="
+        OpLt -> S.Identifier "scm:fx<"
+        OpLte -> S.Identifier "scm:fx<="
+
+      opFloNum = case _ of 
+        OpAdd -> S.Identifier "scm:fl+"
+        OpSubtract -> S.Identifier "scm:fl-"
+        OpMultiply -> S.Identifier "scm:fl*"
+        OpDivide -> S.Identifier "scm:fl/"
+
+      opFloOrd = case _ of
+        OpEq -> S.Identifier "scm:fl="
+        OpNotEq -> S.Identifier "scm:fl="
+        OpGt -> S.Identifier "scm:fl>"
+        OpGte -> S.Identifier "scm:fl>="
+        OpLt -> S.Identifier "scm:fl<"
+        OpLte -> S.Identifier "scm:fl<="
 
       opCharOrd = case _ of
         OpEq -> S.Identifier "scm:char=?"
@@ -219,33 +233,42 @@ codegenPrimOp codegenEnv = case _ of
             _ ->
               S.List [ opCharOrd o', x', y' ]
         OpIntBitAnd ->
-          S.List [ S.Identifier "scm:bitwise-and", x', y' ]
+          S.List [ S.Identifier "scm:fxlogand", x', y' ]
         OpIntBitOr ->
-          S.List  [ S.Identifier "scm:bitwise-or", x', y' ]
+          S.List [ S.Identifier "scm:fxlogor", x', y' ]
         OpIntBitShiftLeft ->
-          S.List [ S.Identifier "scm:bitwise-arithmetic-shift-left", x', y' ]
+          -- shift-left-logical = shift-left-arithmetic
+          S.List [ S.Identifier "scm:fxsll", x', y' ]
         OpIntBitShiftRight ->
-          S.List [ S.Identifier "scm:bitwise-arithmetic-shift-right", x', y' ]
+          -- shift-right-arithmetic preserves signs
+          S.List [ S.Identifier "scm:fxsra", x', y' ]
         OpIntBitXor ->
-          S.List [ S.Identifier "scm:bitwise-xor", x', y' ]
+          S.List [ S.Identifier "scm:fxlogxor", x', y' ]
         OpIntBitZeroFillShiftRight ->
-          S.Identifier "zero-fill-shift-right"
+          -- shift-right-logical follows the invariant:
+          --
+          -- (= (most-positive-fixnum) (fxsrl -1 1))
+          --
+          -- or:
+          --
+          -- top == zshr (-1) 1
+          S.List [ S.Identifier "scm:fxsrl", x', y' ]
         OpIntNum o' ->
-          S.List [ opDtNum o', x', y' ]
+          S.List [ opFixNum o', x', y' ]
         OpIntOrd o' ->
           case o' of
             OpNotEq ->
-              S.List [ S.Identifier "scm:not", S.List [ opDtOrd o', x', y' ] ]
+              S.List [ S.Identifier "scm:not", S.List [ opFixOrd o', x', y' ] ]
             _ ->
-              S.List [ opDtOrd o', x', y' ]
+              S.List [ opFixOrd o', x', y' ]
         OpNumberNum o' ->
-          S.List [ opDtNum o', x', y' ]
+          S.List [ opFloNum o', x', y' ]
         OpNumberOrd o' ->
           case o' of
             OpNotEq ->
-              S.List [ S.Identifier "scm:not", S.List [ opDtOrd o', x', y' ] ]
+              S.List [ S.Identifier "scm:not", S.List [ opFloOrd o', x', y' ] ]
             _ ->
-              S.List [ opDtOrd o', x', y' ]
+              S.List [ opFloOrd o', x', y' ]
         OpStringAppend ->
           S.List [ S.Identifier "scm:string-append", x', y' ]
         OpStringOrd o' ->
@@ -254,5 +277,5 @@ codegenPrimOp codegenEnv = case _ of
           case o' of
             OpNotEq ->
               S.List [ S.Identifier "scm:not", S.List [ opStringOrd o', x', y' ] ]
-            _ -> 
+            _ ->
               S.List [ opStringOrd o', x', y' ]

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -16,7 +16,7 @@ import PureScript.Backend.Chez.Syntax as S
 import PureScript.Backend.Optimizer.Convert (BackendModule, BackendBindingGroup)
 import PureScript.Backend.Optimizer.CoreFn (Ident(..), Literal(..), ModuleName(..), Qualified(..))
 import PureScript.Backend.Optimizer.Semantics (NeutralExpr(..))
-import PureScript.Backend.Optimizer.Syntax (BackendOperator(..), BackendOperator2(..), BackendOperatorNum(..), BackendOperatorOrd(..), BackendSyntax(..), Pair(..))
+import PureScript.Backend.Optimizer.Syntax (BackendOperator(..), BackendOperator1(..), BackendOperator2(..), BackendOperatorNum(..), BackendOperatorOrd(..), BackendSyntax(..), Pair(..))
 import Safe.Coerce (coerce)
 
 type CodegenEnv =
@@ -162,8 +162,23 @@ codegenLiteral codegenEnv = case _ of
 
 codegenPrimOp :: CodegenEnv -> BackendOperator NeutralExpr -> ChezExpr
 codegenPrimOp codegenEnv = case _ of
-  Op1 _ _ ->
-    S.Identifier "unary-prim-op"
+  Op1 o x ->
+    let
+      x' = codegenExpr codegenEnv x
+    in
+      case o of
+        OpBooleanNot ->
+          S.List [ S.Identifier "scm:not", x' ]
+        OpIntBitNot ->
+          S.List [ S.Identifier "scm:fxlognot", x' ]
+        OpIntNegate ->
+          S.List [ S.Identifier "scm:fx-", x' ]
+        OpNumberNegate ->
+          S.List [ S.Identifier "scm:fl-", x' ]
+        OpArrayLength ->
+          S.List [ S.Identifier "scm:vector-length", x' ]
+        OpIsTag _ ->
+          S.Identifier "op-is-tag"
   Op2 o x y ->
     let
       x' = codegenExpr codegenEnv x

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -16,7 +16,7 @@ import PureScript.Backend.Chez.Syntax as S
 import PureScript.Backend.Optimizer.Convert (BackendModule, BackendBindingGroup)
 import PureScript.Backend.Optimizer.CoreFn (Ident(..), Literal(..), ModuleName(..), Qualified(..))
 import PureScript.Backend.Optimizer.Semantics (NeutralExpr(..))
-import PureScript.Backend.Optimizer.Syntax (BackendSyntax(..))
+import PureScript.Backend.Optimizer.Syntax (BackendSyntax(..), Pair(..))
 import Safe.Coerce (coerce)
 
 type CodegenEnv =
@@ -126,8 +126,12 @@ codegenExpr codegenEnv@{ currentModule } (NeutralExpr s) = case s of
     S.Identifier "let-rec"
   Let i l v e ->
     S.chezLet (S.toChezIdent i l) (codegenExpr codegenEnv v) (codegenExpr codegenEnv e)
-  Branch _ _ ->
-    S.Identifier "branch"
+  Branch b o ->
+    let
+      goPair :: Pair NeutralExpr -> { c :: _, e :: _ }
+      goPair (Pair c e) = { c: codegenExpr codegenEnv c, e: codegenExpr codegenEnv e }
+    in
+      S.chezCond (goPair <$> b) (codegenExpr codegenEnv <$> o)
 
   EffectBind _ _ _ _ ->
     S.Identifier "effect-bind"

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -187,6 +187,14 @@ codegenPrimOp codegenEnv = case _ of
       x' = codegenExpr codegenEnv x
       y' = codegenExpr codegenEnv y
 
+      opBooleanOrd = case _ of
+        OpEq -> S.Identifier "scm:boolean=?"
+        OpNotEq -> S.Identifier "scm:boolean=?"
+        OpGt -> S.Identifier "rt:boolean<?"
+        OpGte -> S.Identifier "rt:boolean>=?"
+        OpLt -> S.Identifier "rt:boolean<?"
+        OpLte -> S.Identifier "rt:boolean<=?"
+
       opFixNum = case _ of
         OpAdd -> S.Identifier "scm:fx+"
         OpSubtract -> S.Identifier "scm:fx-"
@@ -238,12 +246,12 @@ codegenPrimOp codegenEnv = case _ of
           S.List [ S.Identifier "scm:and", x', y' ]
         OpBooleanOr ->
           S.List [ S.Identifier "scm:or", x', y' ]
-        OpBooleanOrd _ ->
-          -- Neither R6RS nor Chez defines comparison operators for
-          -- booleans, meaning that we would either have to inject
-          -- the definitions at the call site _or_ provide them
-          -- through a library loaded by _all_ files.
-          S.Identifier "boolean-ord"
+        OpBooleanOrd o' ->
+          case o' of
+            OpNotEq ->
+              S.List [ S.Identifier "scm:not", S.List [ opBooleanOrd o', x', y' ] ]
+            _ ->
+              S.List [ opBooleanOrd o', x', y' ]
         OpCharOrd o' ->
           case o' of
             OpNotEq ->

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -65,7 +65,7 @@ codegenModule { name, bindings, exports, imports, foreign: foreign_ } =
             "scm:"
         ] <> pursImports <> foreignImport
     , exports: exports'
-    , body: { definitions, exprs: [] }
+    , body: { definitions, expressions: [] }
     }
 
 codegenTopLevelBindingGroup

--- a/src/PureScript/Backend/Chez/Runtime.purs
+++ b/src/PureScript/Backend/Chez/Runtime.purs
@@ -2,52 +2,67 @@ module PureScript.Backend.Chez.Runtime where
 
 import Prelude
 
+import Control.Monad.State (runState)
+import Control.Monad.State.Class (class MonadState, modify_)
+import Data.Array as Array
 import Data.Array.NonEmpty as NEA
 import Data.Maybe (Maybe(..))
-import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezImport(..), ChezImportSet(..), ChezLibrary)
+import Data.Traversable (sequence)
+import Data.Tuple (Tuple(..))
+import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezExpr, ChezImport(..), ChezImportSet(..), ChezLibrary)
 import PureScript.Backend.Chez.Syntax as S
 
+makeExportedFunction
+  :: forall m
+   . Monad m
+  => MonadState (Array ChezExport) m
+  => String
+  -> Array String
+  -> ChezExpr
+  -> m ChezDefinition
+makeExportedFunction name args expr = do
+  modify_ $ Array.cons $ ExportIdentifier name
+  pure $ DefineUncurriedFunction name args expr
+
+makeBooleanComparison
+  :: forall m. Monad m => MonadState (Array ChezExport) m => String -> m ChezDefinition
+makeBooleanComparison suffix =
+  makeExportedFunction ("boolean" <> suffix) [ "x", "y" ] $
+    S.List
+      [ S.Identifier $ "scm:fx" <> suffix
+      , S.List [ S.Identifier "boolean->integer", S.Identifier "x" ]
+      , S.List [ S.Identifier "boolean->integer", S.Identifier "y" ]
+      ]
+
 runtimeModule :: ChezLibrary
-runtimeModule =
+runtimeModule = do
+  let
+    Tuple definitions exports = flip runState [] $ sequence
+      [ pure $ DefineUncurriedFunction "boolean->integer" [ "x" ] $ S.List
+          [ S.Identifier "scm:if"
+          , S.Identifier "x"
+          , S.Integer $ S.LiteralDigit "1"
+          , S.Integer $ S.LiteralDigit "0"
+          ]
+      , makeBooleanComparison ">?"
+      , makeBooleanComparison ">=?"
+      , makeBooleanComparison "<=?"
+      , makeBooleanComparison "<?"
+      ]
   { "#!chezscheme": true
   , "#!r6rs": true
   , name:
       { identifiers: NEA.cons' "_Chez_Runtime" [ "lib" ]
       , version: []
       }
-  , exports:
-      [ ExportIdentifier "boolean>?"
-      , ExportIdentifier "boolean>=?"
-      , ExportIdentifier "boolean<=?"
-      , ExportIdentifier "boolean<?"
-      ]
+  , exports
   , imports:
       [ ImportSet $ ImportPrefix
           (ImportLibrary { identifiers: NEA.singleton "chezscheme", version: Nothing })
           "scm:"
       ]
   , body:
-      { definitions:
-          [ DefineUncurriedFunction "boolean->integer" [ "x" ] $ S.List
-              [ S.Identifier "scm:if"
-              , S.Identifier "x"
-              , S.Integer $ S.LiteralDigit "1"
-              , S.Integer $ S.LiteralDigit "0"
-              ]
-          , makeBooleanComparison ">?"
-          , makeBooleanComparison ">=?"
-          , makeBooleanComparison "<=?"
-          , makeBooleanComparison "<?"
-          ]
+      { definitions
       , expressions: []
       }
   }
-
-makeBooleanComparison :: String -> ChezDefinition
-makeBooleanComparison suffix =
-  DefineUncurriedFunction ("boolean" <> suffix) [ "x", "y" ] $
-    S.List
-      [ S.Identifier $ "scm:fx" <> suffix
-      , S.List [ S.Identifier "boolean->integer", S.Identifier "x" ]
-      , S.List [ S.Identifier "boolean->integer", S.Identifier "y" ]
-      ]

--- a/src/PureScript/Backend/Chez/Runtime.purs
+++ b/src/PureScript/Backend/Chez/Runtime.purs
@@ -4,7 +4,8 @@ import Prelude
 
 import Data.Array.NonEmpty as NEA
 import Data.Maybe (Maybe(..))
-import PureScript.Backend.Chez.Syntax (ChezImport(..), ChezImportSet(..), ChezLibrary)
+import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezImport(..), ChezImportSet(..), ChezLibrary)
+import PureScript.Backend.Chez.Syntax as S
 
 runtimeModule :: ChezLibrary
 runtimeModule =
@@ -14,12 +15,39 @@ runtimeModule =
       { identifiers: NEA.cons' "_Chez_Runtime" [ "lib" ]
       , version: []
       }
-  , exports: []
+  , exports:
+      [ ExportIdentifier "boolean>?"
+      , ExportIdentifier "boolean>=?"
+      , ExportIdentifier "boolean<=?"
+      , ExportIdentifier "boolean<?"
+      ]
   , imports:
-      [ ImportSet $ ImportLibrary { identifiers: NEA.singleton "chezscheme", version: Nothing }
+      [ ImportSet $ ImportPrefix
+          (ImportLibrary { identifiers: NEA.singleton "chezscheme", version: Nothing })
+          "scm:"
       ]
   , body:
-      { definitions: []
+      { definitions:
+          [ DefineUncurriedFunction "boolean->integer" [ "x" ] $ S.List
+              [ S.Identifier "scm:if"
+              , S.Identifier "x"
+              , S.Integer $ S.LiteralDigit "1"
+              , S.Integer $ S.LiteralDigit "0"
+              ]
+          , makeBooleanComparison ">?"
+          , makeBooleanComparison ">=?"
+          , makeBooleanComparison "<=?"
+          , makeBooleanComparison "<?"
+          ]
       , expressions: []
       }
   }
+
+makeBooleanComparison :: String -> ChezDefinition
+makeBooleanComparison suffix =
+  DefineUncurriedFunction ("boolean" <> suffix) [ "x", "y" ] $
+    S.List
+      [ S.Identifier $ "scm:fx" <> suffix
+      , S.List [ S.Identifier "boolean->integer", S.Identifier "x" ]
+      , S.List [ S.Identifier "boolean->integer", S.Identifier "y" ]
+      ]

--- a/src/PureScript/Backend/Chez/Runtime.purs
+++ b/src/PureScript/Backend/Chez/Runtime.purs
@@ -1,4 +1,4 @@
-module PureScript.Backend.Chez.Runtime where
+module PureScript.Backend.Chez.Runtime (runtimeModule) where
 
 import Prelude
 

--- a/src/PureScript/Backend/Chez/Runtime.purs
+++ b/src/PureScript/Backend/Chez/Runtime.purs
@@ -1,0 +1,25 @@
+module PureScript.Backend.Chez.Runtime where
+
+import Prelude
+
+import Data.Array.NonEmpty as NEA
+import Data.Maybe (Maybe(..))
+import PureScript.Backend.Chez.Syntax (ChezImport(..), ChezImportSet(..), ChezLibrary)
+
+runtimeModule :: ChezLibrary
+runtimeModule =
+  { "#!chezscheme": true
+  , "#!r6rs": true
+  , name:
+      { identifiers: NEA.cons' "_Chez_Runtime" [ "lib" ]
+      , version: []
+      }
+  , exports: []
+  , imports:
+      [ ImportSet $ ImportLibrary { identifiers: NEA.singleton "chezscheme", version: Nothing }
+      ]
+  , body:
+      { definitions: []
+      , expressions: []
+      }
+  }

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -287,6 +287,17 @@ toChezIdent i (Level l) = case i of
 
 --
 
+chezCond :: NonEmptyArray { c :: ChezExpr, e :: ChezExpr } -> Maybe ChezExpr -> ChezExpr
+chezCond b o =
+  let
+    b' :: ChezExpr
+    b' = List $ NonEmptyArray.toArray b <#> \{ c, e } -> List [ c, e ]
+
+    o' :: Prim.Array ChezExpr
+    o' = Array.fromFoldable o <#> \x -> List [ Identifier "scm:else", x ]
+  in
+    List $ [ Identifier "scm:cond", b' ] <> o'
+
 chezCurriedApplication :: ChezExpr -> NonEmptyArray ChezExpr -> ChezExpr
 chezCurriedApplication f s = NonEmptyArray.foldl1 app $ NonEmptyArray.cons f s
 

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -258,7 +258,7 @@ printDefinition = case _ of
     printNamedIndentedList (D.text "scm:define " <> D.text ident)
       $ printCurriedApp (NEA.toArray args) expr
   DefineUncurriedFunction ident args expr ->
-    printNamedIndentedList (D.text "scm:define" <> D.text ident)
+    printNamedIndentedList (D.text "scm:define " <> D.text ident)
       $ printNamedIndentedList
           (D.text "scm:lambda " <> printList (D.words $ map D.text args))
           (printChezExpr expr)

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -76,7 +76,7 @@ data ChezImportSet
 
 type LibraryBody =
   { definitions :: Prim.Array ChezDefinition
-  , exprs :: Prim.Array ChezExpr
+  , expressions :: Prim.Array ChezExpr
   }
 
 data ChezDefinition
@@ -236,7 +236,7 @@ printBody :: LibraryBody -> Doc Void
 printBody lib = do
   let
     defs = map printDefinition lib.definitions
-    exprs = map printChezExpr lib.exprs
+    exprs = map printChezExpr lib.expressions
   linesSeparated $ defs <> exprs
 
 printNamedIndentedList :: Doc Void -> Doc Void -> Doc Void

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -290,13 +290,13 @@ toChezIdent i (Level l) = case i of
 chezCond :: NonEmptyArray { c :: ChezExpr, e :: ChezExpr } -> Maybe ChezExpr -> ChezExpr
 chezCond b o =
   let
-    b' :: ChezExpr
-    b' = List $ NonEmptyArray.toArray b <#> \{ c, e } -> List [ c, e ]
+    b' :: Prim.Array ChezExpr
+    b' = NonEmptyArray.toArray b <#> \{ c, e } -> List [ c, e ]
 
     o' :: Prim.Array ChezExpr
     o' = Array.fromFoldable o <#> \x -> List [ Identifier "scm:else", x ]
   in
-    List $ [ Identifier "scm:cond", b' ] <> o'
+    List $ [ Identifier "scm:cond" ] <> b' <> o'
 
 chezCurriedApplication :: ChezExpr -> NonEmptyArray ChezExpr -> ChezExpr
 chezCurriedApplication f s = NonEmptyArray.foldl1 app $ NonEmptyArray.cons f s

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -82,7 +82,7 @@ type LibraryBody =
 data ChezDefinition
   = DefineValue Prim.String ChezExpr
   | DefineCurriedFunction Prim.String (NonEmptyArray Prim.String) ChezExpr
-  | DefineUncurriedFunction Prim.String (NonEmptyArray Prim.String) ChezExpr
+  | DefineUncurriedFunction Prim.String (Prim.Array Prim.String) ChezExpr
 
 newtype LiteralDigit = LiteralDigit Prim.String
 
@@ -280,8 +280,8 @@ printChezExpr e = case e of
   Identifier x -> D.text x
   List xs -> D.text "(" <> D.words (printChezExpr <$> xs) <> D.text ")"
 
-toChezIdent :: Maybe Ident -> Level -> Ident
-toChezIdent i (Level l) = Ident $ case i of
+toChezIdent :: Maybe Ident -> Level -> Prim.String
+toChezIdent i (Level l) = case i of
   Just (Ident i') -> i' <> show l
   Nothing -> "_" <> show l
 
@@ -290,11 +290,11 @@ toChezIdent i (Level l) = Ident $ case i of
 chezCurriedApplication :: ChezExpr -> NonEmptyArray ChezExpr -> ChezExpr
 chezCurriedApplication f s = NonEmptyArray.foldl1 app $ NonEmptyArray.cons f s
 
-chezCurriedFunction :: NonEmptyArray Ident -> ChezExpr -> ChezExpr
+chezCurriedFunction :: NonEmptyArray Prim.String -> ChezExpr -> ChezExpr
 chezCurriedFunction a e = Array.foldr lambda e $ NonEmptyArray.toArray a
 
-chezLet :: Ident -> ChezExpr -> ChezExpr -> ChezExpr
-chezLet (Ident i) v e = List [ Identifier "scm:letrec*", List [ List [ Identifier i, v ] ], e ]
+chezLet :: Prim.String -> ChezExpr -> ChezExpr -> ChezExpr
+chezLet i v e = List [ Identifier "scm:letrec*", List [ List [ Identifier i, v ] ], e ]
 
 --
 
@@ -350,8 +350,8 @@ record r =
           ]
       ] <> (field <$> r) <> [ Identifier "$record" ]
 
-lambda :: Ident -> ChezExpr -> ChezExpr
-lambda a e = List [ Identifier "scm:lambda", List [ Identifier $ coerce a ], e ]
+lambda :: Prim.String -> ChezExpr -> ChezExpr
+lambda a e = List [ Identifier "scm:lambda", List [ Identifier a ], e ]
 
 vector :: Prim.Array ChezExpr -> ChezExpr
 vector = List <<< Array.cons (Identifier "scm:vector")

--- a/test-snapshots/packages.dhall
+++ b/test-snapshots/packages.dhall
@@ -8,3 +8,8 @@ in  upstream
     , repo = "https://github.com/purescm/purescript-prelude.git"
     , version = "63ff5a24beba191c8fda919a58489f36bde2d506"
     }
+  with partial =
+    { dependencies = [] : List Text
+    , repo = "https://github.com/purescm/purescript-partial.git"
+    , version = "d8b6daf068e4aab0ad85a42d0f890ed37f416923"
+    }

--- a/test-snapshots/packages.dhall
+++ b/test-snapshots/packages.dhall
@@ -1,0 +1,10 @@
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.7-20230320/packages.dhall
+        sha256:6f2a4b50b793f304d3a64fd25d631de990de280981c73b0683a090e4fa499f0d
+
+in  upstream
+  with prelude =
+    { dependencies = [] : List Text
+    , repo = "https://github.com/purescm/purescript-prelude.git"
+    , version = "63ff5a24beba191c8fda919a58489f36bde2d506"
+    }

--- a/test-snapshots/snapshots-input/Snapshot.Branch.purs
+++ b/test-snapshots/snapshots-input/Snapshot.Branch.purs
@@ -9,3 +9,8 @@ g = case _ of
   1 -> 2
   2 -> 3
   _ -> 0
+
+h :: Number -> Number
+h = case _ of
+  3.14 -> 3.14159
+  _ -> 0.0

--- a/test-snapshots/snapshots-input/Snapshot.Branch.purs
+++ b/test-snapshots/snapshots-input/Snapshot.Branch.purs
@@ -1,0 +1,11 @@
+module Snapshot.Branch where
+
+f :: Boolean -> Boolean -> Boolean -> Int
+f x y z = if x then if y then if z then 0 else 1 else 2 else 3
+
+g :: Int -> Int
+g = case _ of
+  0 -> 1
+  1 -> 2
+  2 -> 3
+  _ -> 0

--- a/test-snapshots/snapshots-input/Snapshot.Branch.purs
+++ b/test-snapshots/snapshots-input/Snapshot.Branch.purs
@@ -14,3 +14,10 @@ h :: Number -> Number
 h = case _ of
   3.14 -> 3.14159
   _ -> 0.0
+
+i :: Boolean -> Boolean -> Boolean
+i = case _, _ of
+  true, true -> false
+  false, false -> true
+  false, true -> false
+  true, false -> true

--- a/test-snapshots/snapshots-input/Snapshot.Branch.purs
+++ b/test-snapshots/snapshots-input/Snapshot.Branch.purs
@@ -1,5 +1,7 @@
 module Snapshot.Branch where
 
+import Partial.Unsafe (unsafePartial)
+
 f :: Boolean -> Boolean -> Boolean -> Int
 f x y z = if x then if y then if z then 0 else 1 else 2 else 3
 
@@ -11,9 +13,8 @@ g = case _ of
   _ -> 0
 
 h :: Number -> Number
-h = case _ of
+h = unsafePartial case _ of
   3.14 -> 3.14159
-  _ -> 0.0
 
 i :: Boolean -> Boolean -> Boolean
 i = case _, _ of

--- a/test-snapshots/snapshots-input/Snapshot.Comparison.purs
+++ b/test-snapshots/snapshots-input/Snapshot.Comparison.purs
@@ -1,0 +1,53 @@
+module Snapshot.Comparison where
+
+import Prelude
+
+integerComparison :: Int -> Int -> Array Boolean
+integerComparison x y =
+  [ x == y
+  , x /= y
+  , x < y
+  , x <= y
+  , x >= y
+  , x > y
+  ]
+
+booleanComparison :: Boolean -> Boolean -> Array Boolean
+booleanComparison x y =
+  [ x == y
+  , x /= y
+  , x < y
+  , x <= y
+  , x >= y
+  , x > y
+  ]
+
+numberComparison :: Number -> Number -> Array Boolean
+numberComparison x y =
+  [ x == y
+  , x /= y
+  , x < y
+  , x <= y
+  , x >= y
+  , x > y
+  ]
+
+charComparison :: Char -> Char -> Array Boolean
+charComparison x y =
+  [ x == y
+  , x /= y
+  , x < y
+  , x <= y
+  , x >= y
+  , x > y
+  ]
+
+stringComparison :: String -> String -> Array Boolean
+stringComparison x y =
+  [ x == y
+  , x /= y
+  , x < y
+  , x <= y
+  , x >= y
+  , x > y
+  ]

--- a/test-snapshots/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Branch.ss
@@ -18,11 +18,11 @@
 
   (scm:define h
     (scm:lambda (v0)
-      (scm:cond ((scm:fl= v0 3.14) 3.14159) (scm:else 0.0))))
+      (scm:cond ((scm:fl=? v0 3.14) 3.14159) (scm:else 0.0))))
 
   (scm:define g
     (scm:lambda (v0)
-      (scm:cond ((scm:fx= v0 0) 1) ((scm:fx= v0 1) 2) ((scm:fx= v0 2) 3) (scm:else 0))))
+      (scm:cond ((scm:fx=? v0 0) 1) ((scm:fx=? v0 1) 2) ((scm:fx=? v0 2) 3) (scm:else 0))))
 
   (scm:define f
     (scm:lambda (x0)

--- a/test-snapshots/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Branch.ss
@@ -11,11 +11,11 @@
 
   (scm:define h
     (scm:lambda (v0)
-      (scm:cond ((scm:= v0 3.14) 3.14159) (scm:else 0.0))))
+      (scm:cond ((scm:fl= v0 3.14) 3.14159) (scm:else 0.0))))
 
   (scm:define g
     (scm:lambda (v0)
-      (scm:cond ((scm:= v0 0) 1) ((scm:= v0 1) 2) ((scm:= v0 2) 3) (scm:else 0))))
+      (scm:cond ((scm:fx= v0 0) 1) ((scm:fx= v0 1) 2) ((scm:fx= v0 2) 3) (scm:else 0))))
 
   (scm:define f
     (scm:lambda (x0)

--- a/test-snapshots/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Branch.ss
@@ -4,9 +4,14 @@
   (Snapshot.Branch lib)
   (export
     f
-    g)
+    g
+    h)
   (import
     (prefix (chezscheme) scm:))
+
+  (scm:define h
+    (scm:lambda (v0)
+      (scm:cond ((scm:= v0 3.14) 3.14159) (scm:else 0.0))))
 
   (scm:define g
     (scm:lambda (v0)

--- a/test-snapshots/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Branch.ss
@@ -1,0 +1,19 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Branch lib)
+  (export
+    f
+    g)
+  (import
+    (prefix (chezscheme) scm:))
+
+  (scm:define g
+    (scm:lambda (v0)
+      (scm:cond ((prim-op 1) (prim-op 2) (prim-op 3)) (scm:else 0))))
+
+  (scm:define f
+    (scm:lambda (x0)
+      (scm:lambda (y1)
+        (scm:lambda (z2)
+          (scm:cond ((x0 (scm:cond ((y1 (scm:cond ((z2 0)) (scm:else 1)))) (scm:else 2)))) (scm:else 3)))))))

--- a/test-snapshots/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Branch.ss
@@ -7,7 +7,8 @@
     g
     h)
   (import
-    (prefix (chezscheme) scm:))
+    (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:))
 
   (scm:define h
     (scm:lambda (v0)

--- a/test-snapshots/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Branch.ss
@@ -18,7 +18,7 @@
 
   (scm:define h
     (scm:lambda (v0)
-      (scm:cond ((scm:fl=? v0 3.14) 3.14159) (scm:else 0.0))))
+      (scm:cond ((scm:fl=? v0 3.14) 3.14159) (scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))))))
 
   (scm:define g
     (scm:lambda (v0)

--- a/test-snapshots/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Branch.ss
@@ -10,10 +10,10 @@
 
   (scm:define g
     (scm:lambda (v0)
-      (scm:cond ((prim-op 1) (prim-op 2) (prim-op 3)) (scm:else 0))))
+      (scm:cond (prim-op 1) (prim-op 2) (prim-op 3) (scm:else 0))))
 
   (scm:define f
     (scm:lambda (x0)
       (scm:lambda (y1)
         (scm:lambda (z2)
-          (scm:cond ((x0 (scm:cond ((y1 (scm:cond ((z2 0)) (scm:else 1)))) (scm:else 2)))) (scm:else 3)))))))
+          (scm:cond (x0 (scm:cond (y1 (scm:cond (z2 0) (scm:else 1))) (scm:else 2))) (scm:else 3)))))))

--- a/test-snapshots/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Branch.ss
@@ -5,10 +5,16 @@
   (export
     f
     g
-    h)
+    h
+    i)
   (import
     (prefix (chezscheme) scm:)
     (prefix (_Chez_Runtime lib) rt:))
+
+  (scm:define i
+    (scm:lambda (v0)
+      (scm:lambda (v11)
+        (scm:cond (v0 (scm:not v11)) ((scm:not v11) #t) (v11 #f) (scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match"))))))))
 
   (scm:define h
     (scm:lambda (v0)

--- a/test-snapshots/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Branch.ss
@@ -10,7 +10,7 @@
 
   (scm:define g
     (scm:lambda (v0)
-      (scm:cond (prim-op 1) (prim-op 2) (prim-op 3) (scm:else 0))))
+      (scm:cond ((scm:= v0 0) 1) ((scm:= v0 1) 2) ((scm:= v0 2) 3) (scm:else 0))))
 
   (scm:define f
     (scm:lambda (x0)

--- a/test-snapshots/snapshots-output/Snapshot.Comparison.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Comparison.ss
@@ -1,0 +1,38 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Comparison lib)
+  (export
+    booleanComparison
+    charComparison
+    integerComparison
+    numberComparison
+    stringComparison)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:))
+
+  (scm:define stringComparison
+    (scm:lambda (x0)
+      (scm:lambda (y1)
+        (scm:vector (scm:string=? x0 y1) (scm:not (scm:string=? x0 y1)) (scm:string<? x0 y1) (scm:string<=? x0 y1) (scm:string>=? x0 y1) (scm:string>? x0 y1)))))
+
+  (scm:define numberComparison
+    (scm:lambda (x0)
+      (scm:lambda (y1)
+        (scm:vector (scm:fl= x0 y1) (scm:not (scm:fl= x0 y1)) (scm:fl< x0 y1) (scm:fl<= x0 y1) (scm:fl>= x0 y1) (scm:fl> x0 y1)))))
+
+  (scm:define integerComparison
+    (scm:lambda (x0)
+      (scm:lambda (y1)
+        (scm:vector (scm:fx= x0 y1) (scm:not (scm:fx= x0 y1)) (scm:fx< x0 y1) (scm:fx<= x0 y1) (scm:fx>= x0 y1) (scm:fx> x0 y1)))))
+
+  (scm:define charComparison
+    (scm:lambda (x0)
+      (scm:lambda (y1)
+        (scm:vector (scm:char=? x0 y1) (scm:not (scm:char=? x0 y1)) (scm:char<? x0 y1) (scm:char<=? x0 y1) (scm:char>=? x0 y1) (scm:char>? x0 y1)))))
+
+  (scm:define booleanComparison
+    (scm:lambda (x0)
+      (scm:lambda (y1)
+        (scm:vector (scm:boolean=? x0 y1) (scm:not (scm:boolean=? x0 y1)) (rt:boolean<? x0 y1) (rt:boolean<=? x0 y1) (rt:boolean>=? x0 y1) (rt:boolean<? x0 y1))))))

--- a/test-snapshots/snapshots-output/Snapshot.Comparison.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Comparison.ss
@@ -20,12 +20,12 @@
   (scm:define numberComparison
     (scm:lambda (x0)
       (scm:lambda (y1)
-        (scm:vector (scm:fl= x0 y1) (scm:not (scm:fl= x0 y1)) (scm:fl< x0 y1) (scm:fl<= x0 y1) (scm:fl>= x0 y1) (scm:fl> x0 y1)))))
+        (scm:vector (scm:fl=? x0 y1) (scm:not (scm:fl=? x0 y1)) (scm:fl<? x0 y1) (scm:fl<=? x0 y1) (scm:fl>=? x0 y1) (scm:fl>? x0 y1)))))
 
   (scm:define integerComparison
     (scm:lambda (x0)
       (scm:lambda (y1)
-        (scm:vector (scm:fx= x0 y1) (scm:not (scm:fx= x0 y1)) (scm:fx< x0 y1) (scm:fx<= x0 y1) (scm:fx>= x0 y1) (scm:fx> x0 y1)))))
+        (scm:vector (scm:fx=? x0 y1) (scm:not (scm:fx=? x0 y1)) (scm:fx<? x0 y1) (scm:fx<=? x0 y1) (scm:fx>=? x0 y1) (scm:fx>? x0 y1)))))
 
   (scm:define charComparison
     (scm:lambda (x0)
@@ -35,4 +35,4 @@
   (scm:define booleanComparison
     (scm:lambda (x0)
       (scm:lambda (y1)
-        (scm:vector (scm:boolean=? x0 y1) (scm:not (scm:boolean=? x0 y1)) (rt:boolean<? x0 y1) (rt:boolean<=? x0 y1) (rt:boolean>=? x0 y1) (rt:boolean<? x0 y1))))))
+        (scm:vector (scm:boolean=? x0 y1) (scm:not (scm:boolean=? x0 y1)) (rt:boolean<? x0 y1) (rt:boolean<=? x0 y1) (rt:boolean>=? x0 y1) (rt:boolean>? x0 y1))))))

--- a/test-snapshots/snapshots-output/Snapshot.Function.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Function.ss
@@ -6,7 +6,8 @@
     f
     g)
   (import
-    (prefix (chezscheme) scm:))
+    (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:))
 
   (scm:define f
     (scm:lambda (x0)

--- a/test-snapshots/snapshots-output/Snapshot.Import.Impl.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Import.Impl.ss
@@ -7,6 +7,7 @@
     fortyTwo)
   (import
     (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:)
     (Snapshot.Import.Impl foreign))
 
   (scm:define fortyTwo

--- a/test-snapshots/snapshots-output/Snapshot.Import.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Import.ss
@@ -6,6 +6,7 @@
     fortyThree)
   (import
     (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:)
     (prefix (Snapshot.Import.Impl lib) Snapshot.Import.Impl.))
 
   (scm:define fortyThree

--- a/test-snapshots/snapshots-output/Snapshot.Literals.ss
+++ b/test-snapshots/snapshots-output/Snapshot.Literals.ss
@@ -14,7 +14,8 @@
     record2
     string)
   (import
-    (prefix (chezscheme) scm:))
+    (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:))
 
   (scm:define string
     "string")

--- a/test-snapshots/spago.dhall
+++ b/test-snapshots/spago.dhall
@@ -1,7 +1,5 @@
 { name = "snapshots"
-, dependencies =
-  [ "prelude"
-  ]
+, dependencies = [ "partial", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "snapshots-input/**/*.purs" ]
 }

--- a/test-snapshots/spago.dhall
+++ b/test-snapshots/spago.dhall
@@ -2,6 +2,6 @@
 , dependencies =
   [ "prelude"
   ]
-, packages = ../packages.dhall
+, packages = ./packages.dhall
 , sources = [ "snapshots-input/**/*.purs" ]
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -42,6 +42,7 @@ import Node.Path as Path
 import Node.Process as Process
 import Partial.Unsafe (unsafeCrashWith)
 import PureScript.Backend.Chez.Convert (codegenModule)
+import PureScript.Backend.Chez.Runtime (runtimeModule)
 import PureScript.Backend.Chez.Syntax as S
 import PureScript.Backend.Optimizer.Builder (buildModules)
 import PureScript.Backend.Optimizer.Convert (BackendModule)
@@ -93,6 +94,12 @@ runSnapshotTests { accept, filter } = do
   let testOut = Path.concat [ snapshotDir, "test-out" ]
   mkdirp snapshotsOut
   mkdirp testOut
+  -- RUNTIME
+  let runtimePath = Path.concat [ testOut, "_Chez_Runtime" ]
+  mkdirp runtimePath
+  let runtimeFilePath = Path.concat [ runtimePath, "lib.ss" ]
+  let runtimeContents = Dodo.print plainText Dodo.twoSpaces $ S.printLibrary $ runtimeModule
+  FS.writeTextFile UTF8 runtimeFilePath runtimeContents
   coreFnModulesFromOutput "output" filter >>= case _ of
     Left errors -> do
       for_ errors \(Tuple filePath err) -> do


### PR DESCRIPTION
This PR implements code generation for `Branch`, `PrimOp`, and `Fail` (partially, see comment in source). This also adds a runtime module which provides functions that are otherwise not present in the standard library.