### PR TITLE
Implement data constructors codegen

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -49,8 +49,8 @@ let additions =
           , "unsafe-coerce"
           ]
         , repo =
-            "https://github.com/aristanetworks/purescript-backend-optimizer"
-        , version = "purs-backend-es-v1.3.2"
+            "https://github.com/JordanMartinez/purescript-backend-optimizer"
+        , version = "add-ty-con-info"
         }
       , node-glob-basic =
         { dependencies =

--- a/spago.yaml
+++ b/spago.yaml
@@ -47,8 +47,8 @@ workspace:
     registry: 19.1.0
   extra_packages:
     backend-optimizer:
-      git: https://github.com/aristanetworks/purescript-backend-optimizer
-      ref: purs-backend-es-v1.3.2
+      git: https://github.com/JordanMartinez/purescript-backend-optimizer
+      ref: add-ty-con-info
       dependencies:
         - aff
         - ansi

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -14,7 +14,7 @@ import Data.Tuple (Tuple(..), uncurry)
 import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezExpr, ChezImport(..), ChezImportSet(..), ChezLibrary)
 import PureScript.Backend.Chez.Syntax as S
 import PureScript.Backend.Optimizer.Convert (BackendModule, BackendBindingGroup)
-import PureScript.Backend.Optimizer.CoreFn (Ident(..), Literal(..), ModuleName(..), Qualified(..))
+import PureScript.Backend.Optimizer.CoreFn (Ident(..), Literal(..), ModuleName(..))
 import PureScript.Backend.Optimizer.Semantics (NeutralExpr(..))
 import PureScript.Backend.Optimizer.Syntax (BackendOperator(..), BackendOperator1(..), BackendOperator2(..), BackendOperatorNum(..), BackendOperatorOrd(..), BackendSyntax(..), Pair(..))
 import Safe.Coerce (coerce)
@@ -91,11 +91,8 @@ codegenTopLevelBinding codegenEnv (Tuple (Ident i) n) =
 
 codegenExpr :: CodegenEnv -> NeutralExpr -> ChezExpr
 codegenExpr codegenEnv@{ currentModule } (NeutralExpr s) = case s of
-  Var (Qualified (Just moduleName) (Ident v))
-    | currentModule == moduleName -> S.Identifier v
-    | otherwise -> S.Identifier $ coerce moduleName <> "." <> v
-  Var (Qualified Nothing (Ident v)) ->
-    S.Identifier v
+  Var qi ->
+    S.Identifier $ S.resolve currentModule qi
   Local i l ->
     S.Identifier $ coerce $ S.toChezIdent i l
   Lit l ->

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -13,7 +13,7 @@ import Data.Newtype (class Newtype, un)
 import Dodo (Doc)
 import Dodo as D
 import Prim as Prim
-import PureScript.Backend.Optimizer.CoreFn (Ident(..), ModuleName(..), Prop(..))
+import PureScript.Backend.Optimizer.CoreFn (Ident(..), ModuleName(..), Prop(..), Qualified(..))
 import PureScript.Backend.Optimizer.Syntax (Level(..))
 import Safe.Coerce (coerce)
 
@@ -97,6 +97,12 @@ data ChezExpr
   | Boolean Prim.Boolean
   | Identifier Prim.String
   | List (Prim.Array ChezExpr)
+
+resolve :: ModuleName -> Qualified Ident -> Prim.String
+resolve _ (Qualified Nothing (Ident i)) = i
+resolve currentModule (Qualified (Just m) (Ident i))
+  | currentModule == m = i
+  | otherwise = coerce m <> "." <> i
 
 printWrap :: Doc Void -> Doc Void -> Doc Void -> Doc Void
 printWrap l r x = l <> x <> r

--- a/test-snapshots/src/snapshots-input/Snapshot.Constructor.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Constructor.purs
@@ -1,0 +1,7 @@
+module Snapshot.Constructor where
+
+data Maybe a = Just a | Nothing
+
+data Tree a
+  = Nil
+  | Node (Tree a) a (Tree a)

--- a/test-snapshots/src/snapshots-input/Snapshot.ConstructorAccessor.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.ConstructorAccessor.purs
@@ -1,0 +1,47 @@
+module Snapshot.ConstructorAccessor where
+
+import Prelude
+
+data Foo = Foo Int Int Int
+
+-- A constructor that is partially applied to its arguments.
+x :: Int -> Int -> Foo 
+x = Foo 1
+
+y :: Int -> Foo
+y = Foo 1 1
+
+z :: Foo
+z = Foo 1 1 1
+
+-- more pattern matching tests
+data NoArgs = NoArgs
+
+test1 :: NoArgs -> Boolean
+test1 = case _ of
+  NoArgs -> true
+
+data HasArgs = HasArgs Int Int Int
+
+test2 :: HasArgs -> Int
+test2 = case _ of
+  HasArgs i1 _ _ -> i1
+
+test3 :: HasArgs -> Int
+test3 = case _ of
+  HasArgs i1 i2 i3 
+    | i1 < i3 -> i1
+    | otherwise -> i2
+
+data SumWithArgs
+  = First Int
+  | Last Int
+
+test4 :: SumWithArgs -> Int
+test4 = case _ of
+  First i -> i
+  Last i -> i
+
+test5 :: Partial => SumWithArgs -> Int
+test5 = case _ of
+  First i -> i

--- a/test-snapshots/src/snapshots-output/Snapshot.Constructor.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Constructor.ss
@@ -1,0 +1,47 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Constructor lib)
+  (export
+    Just
+    Just-value0
+    Just?
+    Nil
+    Nil?
+    Node
+    Node*
+    Node-value0
+    Node-value1
+    Node-value2
+    Node?
+    Nothing
+    Nothing?)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:))
+
+  (scm:define Nil
+    (scm:quote Nil))
+
+  (scm:define Nil?
+    (scm:lambda (v)
+      (scm:eq? (scm:quote Nil) v)))
+
+  (scm:define-record-type (Node$ Node* Node?)
+    (scm:fields (scm:immutable value0 Node-value0) (scm:immutable value1 Node-value1) (scm:immutable value2 Node-value2)))
+
+  (scm:define Node
+    (scm:lambda (value0)
+      (scm:lambda (value1)
+        (scm:lambda (value2)
+          (Node* value0 value1 value2)))))
+
+  (scm:define-record-type (Just$ Just Just?)
+    (scm:fields (scm:immutable value0 Just-value0)))
+
+  (scm:define Nothing
+    (scm:quote Nothing))
+
+  (scm:define Nothing?
+    (scm:lambda (v)
+      (scm:eq? (scm:quote Nothing) v))))

--- a/test-snapshots/src/snapshots-output/Snapshot.ConstructorAccessor.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.ConstructorAccessor.ss
@@ -1,0 +1,97 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.ConstructorAccessor lib)
+  (export
+    First
+    First-value0
+    First?
+    Foo
+    Foo*
+    Foo-value0
+    Foo-value1
+    Foo-value2
+    Foo?
+    HasArgs
+    HasArgs*
+    HasArgs-value0
+    HasArgs-value1
+    HasArgs-value2
+    HasArgs?
+    Last
+    Last-value0
+    Last?
+    NoArgs
+    NoArgs?
+    test1
+    test2
+    test3
+    test4
+    test5
+    x
+    y
+    z)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:))
+
+  (scm:define-record-type (First$ First First?)
+    (scm:fields (scm:immutable value0 First-value0)))
+
+  (scm:define-record-type (Last$ Last Last?)
+    (scm:fields (scm:immutable value0 Last-value0)))
+
+  (scm:define NoArgs
+    (scm:quote NoArgs))
+
+  (scm:define NoArgs?
+    (scm:lambda (v)
+      (scm:eq? (scm:quote NoArgs) v)))
+
+  (scm:define-record-type (HasArgs$ HasArgs* HasArgs?)
+    (scm:fields (scm:immutable value0 HasArgs-value0) (scm:immutable value1 HasArgs-value1) (scm:immutable value2 HasArgs-value2)))
+
+  (scm:define HasArgs
+    (scm:lambda (value0)
+      (scm:lambda (value1)
+        (scm:lambda (value2)
+          (HasArgs* value0 value1 value2)))))
+
+  (scm:define-record-type (Foo$ Foo* Foo?)
+    (scm:fields (scm:immutable value0 Foo-value0) (scm:immutable value1 Foo-value1) (scm:immutable value2 Foo-value2)))
+
+  (scm:define Foo
+    (scm:lambda (value0)
+      (scm:lambda (value1)
+        (scm:lambda (value2)
+          (Foo* value0 value1 value2)))))
+
+  (scm:define z
+    (Foo* 1 1 1))
+
+  (scm:define y
+    ((Foo 1) 1))
+
+  (scm:define x
+    (Foo 1))
+
+  (scm:define test5
+    (scm:lambda ($__unused0)
+      (scm:lambda (v1)
+        (scm:cond ((First? v1) (First-value0 v1)) (scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match"))))))))
+
+  (scm:define test4
+    (scm:lambda (v0)
+      (scm:cond ((First? v0) (First-value0 v0)) ((Last? v0) (Last-value0 v0)) (scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))))))
+
+  (scm:define test3
+    (scm:lambda (v0)
+      (scm:cond ((scm:fx<? (HasArgs-value0 v0) (HasArgs-value2 v0)) (HasArgs-value0 v0)) (scm:else (HasArgs-value1 v0)))))
+
+  (scm:define test2
+    (scm:lambda (v0)
+      (HasArgs-value0 v0)))
+
+  (scm:define test1
+    (scm:lambda (v0)
+      #t)))


### PR DESCRIPTION
This PR is a rework of #85.

Constructors are implemented in the following way:
    
  - If their arity is zero, the structure representing the constructor
    is a simple symbol. E.g. if the constructor is Foo, the symbol is
    'Foo. A constructing function with the same name as the constructor
    is also produced alongside a predicate function whose name has a
    trailing question mark (respectively Foo and Foo?).
  - If the arity is one, Scheme records are used. The record type name
    is the constructor name with a trailing dollar character (e.g. Foo$).
    Constructing and predicate functions are provided by the
    define-record-type form and follow the same conventions as
    described in the previous point. The form takes also care of
    producing accessor functions whose name is Ctor-valueN, where Ctor
    is the constructor name and N is the field offset (e.g. Foo-value0).
  - For constructors with arity greater than one, almost everything
    described in the previous point applies. The differences are that
    the constructor has a trailing asterisk character (e.g. Foo*) and a
    curried constructing function is provided, whose name is the same as
    the constructor name.

Moreover codegen for CtorSaturated, OpIsTag and Accessor with
CtorGetField is also handled.