### PR TITLE
Speed up curried app printing

### DIFF
--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -277,7 +277,7 @@ printDefinition = case _ of
       $ printChezExpr expr
   DefineCurriedFunction ident args expr ->
     printNamedIndentedList (D.text "scm:define " <> D.text ident)
-      $ printCurriedApp (NEA.toArray args) expr
+      $ printCurriedAbs (NEA.toArray args) expr
   DefineUncurriedFunction ident args expr ->
     printNamedIndentedList (D.text "scm:define " <> D.text ident)
       $ printNamedIndentedList
@@ -298,8 +298,8 @@ printDefinition = case _ of
       (recordTypePredicate ident)
       fields
 
-printCurriedApp :: Prim.Array Prim.String -> ChezExpr -> Doc Void
-printCurriedApp args body = Array.foldr foldFn (printChezExpr body) args
+printCurriedAbs :: Prim.Array Prim.String -> ChezExpr -> Doc Void
+printCurriedAbs args body = Array.foldr foldFn (printChezExpr body) args
   where
   foldFn next bodyOrRest =
     printNamedIndentedList

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -299,12 +299,12 @@ printDefinition = case _ of
       fields
 
 printCurriedApp :: Prim.Array Prim.String -> ChezExpr -> Doc Void
-printCurriedApp args body = case Array.uncons args of
-  Nothing -> printChezExpr body
-  Just { head, tail } ->
+printCurriedApp args body = Array.foldr foldFn (printChezExpr body) args
+  where
+  foldFn next bodyOrRest =
     printNamedIndentedList
-      (D.text "scm:lambda " <> printList (D.text head))
-      (printCurriedApp tail body)
+      (D.words [ D.text $ scmPrefixed "lambda", printList (D.text next) ])
+      bodyOrRest
 
 printChezExpr :: forall a. ChezExpr -> Doc a
 printChezExpr e = case e of


### PR DESCRIPTION
Remove unneeded `uncons`ing

I noticed this while working on #98. Depends on #98.