### PR TITLE
Print cst parse errors

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -133,7 +133,7 @@ runSnapshotTests { accept, filter } = do
             let snapshotDirFile = Path.concat [ snapshotDir, path ]
             when (Set.member snapshotDirFile snapshotPaths) do
               originalFileSourceCode <- FS.readTextFile UTF8 snapshotDirFile
-              hasMain <- either (\_ -> unsafeCrashWith "canRunMain: parse failure") pure $
+              hasMain <- either unsafeCrashWith pure $
                 canRunMain originalFileSourceCode
               void $ liftEffect $ Ref.modify
                 (Map.insert name ({ formatted, failsWith: hasFails backend, hasMain }))


### PR DESCRIPTION
See https://github.com/purescm/purescm/pull/101#discussion_r1153293633

If the source code file is invalid, we should get notified of this when writing the file.