### PR TITLE
Escape chars in codegen

### DIFF
--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -240,7 +240,7 @@ codegenChar :: Char -> ChezExpr
 codegenChar c = S.Char $ append """#\""" $ escapeChar $ toCharCode c
   where
   escapeChar code
-    | code == toCharCode '\x0000' = "null" -- nul
+    | code == toCharCode '\x0000' = "nul"
     | code == toCharCode '\x0007' = "alarm" -- bel
     | code == toCharCode '\x0008' = "backspace"
     | code == toCharCode '\t' = "tab"

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -6,9 +6,13 @@ import Data.Argonaut as Json
 import Data.Array as Array
 import Data.Array.NonEmpty as NEA
 import Data.Array.NonEmpty as NonEmptyArray
+import Data.Char (toCharCode)
+import Data.Int as Int
 import Data.Maybe (Maybe(..))
+import Data.Monoid (power)
 import Data.Newtype (unwrap, wrap)
 import Data.Set as Set
+import Data.String as String
 import Data.String.CodeUnits as CodeUnits
 import Data.Tuple (Tuple(..), uncurry)
 import Data.Tuple as Tuple
@@ -222,10 +226,36 @@ codegenLiteral codegenEnv = case _ of
   LitInt i -> S.Integer $ wrap $ show i
   LitNumber n -> S.Float $ wrap $ show n
   LitString s -> S.String $ S.jsonToChezString $ Json.stringify $ Json.fromString s
-  LitChar c -> S.Identifier $ "#\\" <> CodeUnits.singleton c
+  LitChar c -> codegenChar c
   LitBoolean b -> S.Identifier $ if b then "#t" else "#f"
   LitArray a -> S.vector $ codegenExpr codegenEnv <$> a
   LitRecord r -> S.record $ (map $ codegenExpr codegenEnv) <$> r
+
+-- > In addition to the standard named characters 
+-- > #\alarm, #\backspace, #\delete, #\esc, #\linefeed, #\newline, #\page, #\return, #\space, and #\tab, 
+-- > Chez Scheme recognizes #\bel, #\ls, #\nel, #\nul, #\rubout, and #\vt (or #\vtab).
+--
+-- Source: https://cisco.github.io/ChezScheme/csug9.5/intro.html#./intro:h1, 6th paragraph
+codegenChar :: Char -> ChezExpr
+codegenChar c = S.Char $ append """#\""" $ escapeChar $ toCharCode c
+  where
+  escapeChar code
+    | code == toCharCode '\x0000' = "null" -- nul
+    | code == toCharCode '\x0007' = "alarm" -- bel
+    | code == toCharCode '\x0008' = "backspace"
+    | code == toCharCode '\t' = "tab"
+    | code == toCharCode '\n' = "linefeed" -- nel/newline; per R6Rs, newline is deprecated
+    | code == toCharCode '\x000B' = "vtab"
+    | code == toCharCode '\x000C' = "page"
+    | code == toCharCode '\r' = "return"
+    | code == toCharCode '\x001B' = "esc"
+    | code == toCharCode ' ' = "space"
+    | code == toCharCode '\x007F' = "delete" -- rubout
+    | code == toCharCode '\x2028' = "ls"
+    | code < 20 || code > 127 = "x" <> (padLeft "0" 4 $ Int.toStringAs Int.hexadecimal code)
+    | otherwise = CodeUnits.singleton c
+
+  padLeft char i s = power char (i - String.length s) <> s
 
 type BlockMode = { effect :: Boolean }
 

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -101,6 +101,7 @@ derive newtype instance Ord LiteralDigit
 data ChezExpr
   = Integer LiteralDigit
   | Float LiteralDigit
+  | Char Prim.String
   | String Prim.String
   | Boolean Prim.Boolean
   | Identifier Prim.String
@@ -204,6 +205,7 @@ escapeIdentifiers lib = lib
     x@(Integer _) -> x
     x@(Float _) -> x
     x@(String _) -> x
+    x@(Char _) -> x
     x@(Boolean _) -> x
 
 printLibrary :: ChezLibrary -> Doc Void
@@ -372,6 +374,7 @@ printChezExpr :: forall a. ChezExpr -> Doc a
 printChezExpr e = case e of
   Integer (LiteralDigit x) -> D.text x
   Float (LiteralDigit x) -> D.text x
+  Char x -> D.text x
   String x -> D.text x
   Boolean x -> D.text $ if x then "#t" else "#f"
   Identifier x -> D.text x

--- a/test-snapshots/src/snapshots-input/Snapshot.Literals.Char.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Literals.Char.purs
@@ -1,0 +1,33 @@
+module Snapshot.Literals.Char where
+
+null = '\x0000' :: Char
+alarm = '\x0007' :: Char
+backspace = '\x0008' :: Char
+tab = '\t' :: Char
+newline = '\n' :: Char
+vtab = '\x000B' :: Char
+page = '\x000C' :: Char
+return = '\r' :: Char
+escape = '\x001B' :: Char
+space = ' ' :: Char
+delete = '\x007F' :: Char
+ls = '\x2028' :: Char
+
+firstPrintableChar = '!' :: Char
+
+singleQuote = '\'' :: Char
+doubleQuote = '\"' :: Char
+
+lastPrintableChar = '~' :: Char -- \x007E
+
+latin1Supplement = '±' :: Char -- \x00B1
+
+latinExtendedA = 'ā' :: Char -- \x0101
+
+latinExtendedB = 'ƀ' :: Char -- \x0180
+
+forallChar = '∀' :: Char -- \x2200
+
+closeToTop = '︙' :: Char -- \xFE19'
+
+biggestChar = '\xFFFF' :: Char

--- a/test-snapshots/src/snapshots-input/Snapshot.Literals.Char.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Literals.Char.purs
@@ -3,11 +3,11 @@ module Snapshot.Literals.Char where
 null = '\x0000' :: Char
 alarm = '\x0007' :: Char
 backspace = '\x0008' :: Char
-tab = '\t' :: Char
-newline = '\n' :: Char
+tab = '\x0009' :: Char
+newline = '\x000A' :: Char
 vtab = '\x000B' :: Char
 page = '\x000C' :: Char
-return = '\r' :: Char
+return = '\x00D' :: Char
 escape = '\x001B' :: Char
 space = ' ' :: Char
 delete = '\x007F' :: Char

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Char.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Char.ss
@@ -48,7 +48,7 @@
     #\page)
 
   (scm:define null
-    #\null)
+    #\nul)
 
   (scm:define newline
     #\linefeed)

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Char.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Char.ss
@@ -1,0 +1,96 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Literals.Char lib)
+  (export
+    alarm
+    backspace
+    biggestChar
+    closeToTop
+    delete
+    doubleQuote
+    escape
+    firstPrintableChar
+    forallChar
+    lastPrintableChar
+    latin1Supplement
+    latinExtendedA
+    latinExtendedB
+    ls
+    newline
+    null
+    page
+    return
+    singleQuote
+    space
+    tab
+    vtab)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:))
+
+  (scm:define vtab
+    #\vtab)
+
+  (scm:define tab
+    #\tab)
+
+  (scm:define space
+    #\space)
+
+  (scm:define singleQuote
+    #\')
+
+  (scm:define return
+    #\return)
+
+  (scm:define page
+    #\page)
+
+  (scm:define null
+    #\null)
+
+  (scm:define newline
+    #\linefeed)
+
+  (scm:define ls
+    #\ls)
+
+  (scm:define latinExtendedB
+    #\x0180)
+
+  (scm:define latinExtendedA
+    #\x0101)
+
+  (scm:define latin1Supplement
+    #\x00b1)
+
+  (scm:define lastPrintableChar
+    #\~)
+
+  (scm:define forallChar
+    #\x2200)
+
+  (scm:define firstPrintableChar
+    #\!)
+
+  (scm:define escape
+    #\esc)
+
+  (scm:define doubleQuote
+    #\")
+
+  (scm:define delete
+    #\delete)
+
+  (scm:define closeToTop
+    #\xfe19)
+
+  (scm:define biggestChar
+    #\xffff)
+
+  (scm:define backspace
+    #\backspace)
+
+  (scm:define alarm
+    #\alarm))


### PR DESCRIPTION
Fixes #65 (the character part)

I decided to only print chars between 21 and 127 because that's what I could input into the Scheme repl without it complaining. This restriction might be incorrect, but this at least unblocks us.