### PR TITLE
Convert PrimUndefined

### DIFF
--- a/src/PureScript/Backend/Chez/Constants.purs
+++ b/src/PureScript/Backend/Chez/Constants.purs
@@ -24,4 +24,4 @@ schemeExt :: String
 schemeExt = ".ss"
 
 undefinedSymbol :: String
-undefinedSymbol = "undefined"
+undefinedSymbol = "purs-undefined"

--- a/src/PureScript/Backend/Chez/Constants.purs
+++ b/src/PureScript/Backend/Chez/Constants.purs
@@ -22,3 +22,6 @@ moduleLib = "lib"
 
 schemeExt :: String
 schemeExt = ".ss"
+
+undefinedSymbol :: String
+undefinedSymbol = "undefined"

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -215,7 +215,8 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
   PrimOp o ->
     codegenPrimOp codegenEnv o
   PrimUndefined ->
-    S.quote $ S.Identifier undefinedSymbol
+    S.app (S.Identifier $ scmPrefixed "gensym")
+      (S.StringExpr $ Json.stringify $ Json.fromString undefinedSymbol)
 
   Fail i ->
     -- Note: This can be improved by using `error`, but it requires

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -21,7 +21,7 @@ import Data.String.Regex.Unsafe as R.Unsafe
 import Data.Tuple (Tuple(..), uncurry)
 import Data.Tuple as Tuple
 import Partial.Unsafe (unsafeCrashWith)
-import PureScript.Backend.Chez.Constants (libChezSchemePrefix, moduleForeign, moduleLib, runtimePrefix, scmPrefixed)
+import PureScript.Backend.Chez.Constants (libChezSchemePrefix, moduleForeign, moduleLib, runtimePrefix, scmPrefixed, undefinedSymbol)
 import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezExpr, ChezImport(..), ChezImportSet(..), ChezLibrary, recordTypeAccessor, recordTypeCurriedConstructor, recordTypePredicate, recordTypeUncurriedConstructor)
 import PureScript.Backend.Chez.Syntax as S
 import PureScript.Backend.Optimizer.Convert (BackendModule, BackendBindingGroup)
@@ -215,7 +215,7 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
   PrimOp o ->
     codegenPrimOp codegenEnv o
   PrimUndefined ->
-    S.Identifier "prim-undefined"
+    S.quote $ S.Identifier undefinedSymbol
 
   Fail i ->
     -- Note: This can be improved by using `error`, but it requires

--- a/test-snapshots/src/snapshots-input/Snapshot.PrimUndefined.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.PrimUndefined.purs
@@ -1,0 +1,15 @@
+-- @inline Snapshot.PrimUndefined.testCase never
+module Snapshot.PrimUndefined where
+
+import Prelude
+
+import Effect (Effect)
+import Test.Assert (assert)
+
+-- One place where PrimUndefined appears is to get the instance dictionary
+-- for a superclass, which is hidden behind a `(lambda (_) ..)` abstraction
+testCase :: forall a. Ring a => a -> a -> a
+testCase x y = x + y
+
+main :: Effect Unit
+main = assert $ testCase 1 1 == 2

--- a/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
@@ -1,0 +1,19 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.PrimUndefined lib)
+  (export
+    main
+    testCase)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (_Chez_Runtime lib) rt:)
+    (prefix (Data.Ring lib) Data.Ring.)
+    (prefix (Test.Assert lib) Test.Assert.))
+
+  (scm:define testCase
+    (scm:lambda (dictRing0)
+      (scm:hashtable-ref ((scm:hashtable-ref dictRing0 "Semiring0" #f) (scm:quote undefined)) "add" #f)))
+
+  (scm:define main
+    (Test.Assert.assert (scm:fx=? (((testCase Data.Ring.ringInt) 1) 1) 2))))

--- a/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
@@ -13,7 +13,7 @@
 
   (scm:define testCase
     (scm:lambda (dictRing0)
-      (scm:hashtable-ref ((scm:hashtable-ref dictRing0 "Semiring0" #f) (scm:quote undefined)) "add" #f)))
+      (scm:hashtable-ref ((scm:hashtable-ref dictRing0 "Semiring0" #f) (scm:gensym "purs-undefined")) "add" #f)))
 
   (scm:define main
     (Test.Assert.assert (scm:fx=? (((testCase Data.Ring.ringInt) 1) 1) 2))))


### PR DESCRIPTION
This converts `PrimUndefined` to a constant symbol `'undefined`. The other choice was `(void)` but using a constant allows us to know that it came from PS code (or potentially Chez Scheme FFI)