### PR TITLE
Convert Update

### DIFF
--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -183,8 +183,8 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
       [ codegenExpr codegenEnv e, S.Integer $ wrap $ show i ]
   Accessor e (GetCtorField qi _ _ _ field _) ->
     S.recordAccessor (codegenExpr codegenEnv e) (flattenQualified currentModule qi) field
-  Update _ _ ->
-    S.Identifier "object-update"
+  Update e p ->
+    S.recordUpdate (codegenExpr codegenEnv e) (map (codegenExpr codegenEnv) <$> p)
 
   CtorSaturated qi _ _ _ xs ->
     S.runUncurriedFn

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -156,8 +156,8 @@ eqQ x y = runUncurriedFn (Identifier $ scmPrefixed "eq?") [ x, y ]
 vector :: Array ChezExpr -> ChezExpr
 vector = List <<< Array.cons (Identifier $ scmPrefixed "vector")
 
-hashtableCopy :: ChezExpr -> ChezExpr
-hashtableCopy h = runUncurriedFn (Identifier $ scmPrefixed "hashtable-copy") [ h ]
+hashtableCopyMut :: ChezExpr -> ChezExpr
+hashtableCopyMut h = runUncurriedFn (Identifier $ scmPrefixed "hashtable-copy") [ h, Bool true ]
 
 recordTypeName :: String -> String
 recordTypeName i = i <> "$"
@@ -189,4 +189,4 @@ recordUpdate h f = do
         , StringExpr $ Json.stringify $ Json.fromString k
         , v
         ]
-  Let false (NonEmptyArray.singleton (Tuple "$record" (hashtableCopy h))) (List (field <$> f))
+  Let false (NonEmptyArray.singleton (Tuple "$record" (hashtableCopyMut h))) (List (field <$> f))

--- a/test-snapshots/spago.yaml
+++ b/test-snapshots/spago.yaml
@@ -7,6 +7,7 @@ package:
     - functions
     - partial
     - prelude
+    - record
     - refs
 workspace:
   package_set:
@@ -49,3 +50,14 @@ workspace:
       dependencies:
         - effect
         - prelude
+    record:
+      git: https://github.com/purescm/purescript-record.git
+      ref: 8a993da0d328f72167a4742e0e2a428a790510bc
+      dependencies: 
+        - functions
+        - prelude
+        - unsafe-coerce
+    unsafe-coerce:
+      git: https://github.com/purescm/purescript-unsafe-coerce.git
+      ref: 20dbd7797e985b631459b8dbd4072cf3096ee1da
+      dependencies: []

--- a/test-snapshots/src/snapshots-input/Snapshot.ConstructorAccessor.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.ConstructorAccessor.purs
@@ -5,7 +5,7 @@ import Prelude
 data Foo = Foo Int Int Int
 
 -- A constructor that is partially applied to its arguments.
-x :: Int -> Int -> Foo 
+x :: Int -> Int -> Foo
 x = Foo 1
 
 y :: Int -> Foo
@@ -29,7 +29,7 @@ test2 = case _ of
 
 test3 :: HasArgs -> Int
 test3 = case _ of
-  HasArgs i1 i2 i3 
+  HasArgs i1 i2 i3
     | i1 < i3 -> i1
     | otherwise -> i2
 

--- a/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.purs
@@ -5,7 +5,10 @@ module Snapshot.Literals.Record where
 import Prelude
 
 import Effect (Effect)
+import Prim.Row (class Lacks)
+import Record as Record
 import Test.Assert (assert)
+import Type.Proxy (Proxy(..))
 
 recordAccess :: forall a r. { fooBarBaz :: a | r } -> a
 recordAccess = _.fooBarBaz
@@ -13,10 +16,16 @@ recordAccess = _.fooBarBaz
 recordUpdate :: forall r. { fooBarBaz :: Int | r } -> { fooBarBaz :: Int | r }
 recordUpdate = _ { fooBarBaz = 10 }
 
+recordAddField :: forall r. Lacks "anotherField" r => { fooBarBaz :: Int | r } -> { fooBarBaz :: Int, anotherField :: Int | r }
+recordAddField = Record.insert (Proxy :: _ "anotherField") 42
+
 main :: Effect Unit
 main = do
   let r = { fooBarBaz: 5 }
   let s = recordUpdate r
-  
+  let t = recordAddField s
+
+  assert $ recordAccess t == 10
+  assert $ t.anotherField == 42
   assert $ recordAccess s == 10
   assert $ recordAccess r == 5

--- a/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.purs
@@ -18,5 +18,5 @@ main = do
   let r = { fooBarBaz: 5 }
   let s = recordUpdate r
   
-  assert $ recordAccess r == 5
   assert $ recordAccess s == 10
+  assert $ recordAccess r == 5

--- a/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.purs
@@ -1,4 +1,22 @@
+-- @inline Snapshot.Literals.Record.recordAccess never
+-- @inline Snapshot.Literals.Record.recordUpdate never
 module Snapshot.Literals.Record where
+
+import Prelude
+
+import Effect (Effect)
+import Test.Assert (assert)
 
 recordAccess :: forall a r. { fooBarBaz :: a | r } -> a
 recordAccess = _.fooBarBaz
+
+recordUpdate :: forall r. { fooBarBaz :: Int | r } -> { fooBarBaz :: Int | r }
+recordUpdate = _ { fooBarBaz = 10 }
+
+main :: Effect Unit
+main = do
+  let r = { fooBarBaz: 5 }
+  let s = recordUpdate r
+  
+  assert $ recordAccess r == 5
+  assert $ recordAccess s == 10

--- a/test-snapshots/src/snapshots-input/Snapshot.Literals.String.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Literals.String.purs
@@ -4,22 +4,26 @@ block1 :: String
 block1 = """block"""
 
 block2 :: String
-block2 = """
+block2 =
+  """
 foo
 bar
 """
 
 block3 :: String
-block3 = """foo
+block3 =
+  """foo
 bar"""
 
 block4 :: String
-block4 = """foo
+block4 =
+  """foo
 bar
 baz"""
 
 block5 :: String
-block5 = """foo
+block5 =
+  """foo
 bar
 baz
 """

--- a/test-snapshots/src/snapshots-input/Snapshot.UncurriedFunction.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.UncurriedFunction.purs
@@ -29,7 +29,7 @@ test3b :: Int
 test3b = runFn2 test3a 1 2
 
 test4a :: EffectFn1 String String
-test4a = mkEffectFn1 $ \a -> do 
+test4a = mkEffectFn1 $ \a -> do
   log a
   pure a
 

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -23,8 +23,7 @@
   (scm:define main
     (scm:let*
       ([r0 (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) (scm:hashtable-set! $record "fooBarBaz" 5) $record)]
-       [s1 (recordUpdate r0)]
-       [_2 (Test.Assert.assert (scm:fx=? (recordAccess r0) 5))])
+       [_1 (Test.Assert.assert (scm:fx=? (recordAccess (recordUpdate r0)) 10))])
         (scm:lambda ()
-          (scm:let ([_ (_2)])
-            ((Test.Assert.assert (scm:fx=? (recordAccess s1) 10))))))))
+          (scm:let ([_ (_1)])
+            ((Test.Assert.assert (scm:fx=? (recordAccess r0) 5))))))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -3,11 +3,28 @@
 (library
   (Snapshot.Literals.Record lib)
   (export
-    recordAccess)
+    main
+    recordAccess
+    recordUpdate)
   (import
     (prefix (chezscheme) scm:)
-    (prefix (_Chez_Runtime lib) rt:))
+    (prefix (_Chez_Runtime lib) rt:)
+    (prefix (Test.Assert lib) Test.Assert.))
+
+  (scm:define recordUpdate
+    (scm:lambda (v0)
+      (scm:let ([$record (scm:hashtable-copy v0)])
+        ((scm:hashtable-set! $record "fooBarBaz" 10)))))
 
   (scm:define recordAccess
     (scm:lambda (v0)
-      (scm:hashtable-ref v0 "fooBarBaz" #f))))
+      (scm:hashtable-ref v0 "fooBarBaz" #f)))
+
+  (scm:define main
+    (scm:let*
+      ([r0 (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) (scm:hashtable-set! $record "fooBarBaz" 5) $record)]
+       [s1 (recordUpdate r0)]
+       [_2 (Test.Assert.assert (scm:fx=? (recordAccess r0) 5))])
+        (scm:lambda ()
+          (scm:let ([_ (_2)])
+            ((Test.Assert.assert (scm:fx=? (recordAccess s1) 10))))))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -3,18 +3,30 @@
 (library
   (Snapshot.Literals.Record lib)
   (export
+    insert
     main
     recordAccess
+    recordAddField
     recordUpdate)
   (import
     (prefix (chezscheme) scm:)
     (prefix (_Chez_Runtime lib) rt:)
-    (prefix (Test.Assert lib) Test.Assert.))
+    (prefix (Record lib) Record.)
+    (prefix (Test.Assert lib) Test.Assert.)
+    (prefix (Type.Proxy lib) Type.Proxy.))
+
+  (scm:define insert
+    (((Record.insert (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) (scm:hashtable-set! $record "reflectSymbol" (scm:lambda (_)
+      "anotherField")) $record)) (scm:gensym "purs-undefined")) (scm:gensym "purs-undefined")))
 
   (scm:define recordUpdate
     (scm:lambda (v0)
-      (scm:let ([$record (scm:hashtable-copy v0)])
+      (scm:let ([$record (scm:hashtable-copy v0 #t)])
         ((scm:hashtable-set! $record "fooBarBaz" 10)))))
+
+  (scm:define recordAddField
+    (scm:lambda (_)
+      ((insert Type.Proxy.Proxy) 42)))
 
   (scm:define recordAccess
     (scm:lambda (v0)
@@ -23,7 +35,13 @@
   (scm:define main
     (scm:let*
       ([r0 (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) (scm:hashtable-set! $record "fooBarBaz" 5) $record)]
-       [_1 (Test.Assert.assert (scm:fx=? (recordAccess (recordUpdate r0)) 10))])
+       [s1 (recordUpdate r0)]
+       [t2 (scm:let ([$record (scm:hashtable-copy s1 #t)])
+        ((scm:hashtable-set! $record "anotherField" 42)))]
+       [_3 (Test.Assert.assert (scm:fx=? (recordAccess t2) 10))])
         (scm:lambda ()
-          (scm:let ([_ (_1)])
-            ((Test.Assert.assert (scm:fx=? (recordAccess r0) 5))))))))
+          (scm:let*
+            ([_ (_3)]
+             [_ ((Test.Assert.assert (scm:fx=? (scm:hashtable-ref t2 "anotherField" #f) 42)))]
+             [_ ((Test.Assert.assert (scm:fx=? (recordAccess s1) 10)))])
+              ((Test.Assert.assert (scm:fx=? (recordAccess r0) 5))))))))


### PR DESCRIPTION
This converts `Update` to a form that:
1. Copies the hashtable
2. Sets the properties

In #129 I mentioned we could do pretty-printing for this and I could work on that in the future (tomorrow).