### PR TITLE
Add initial chez-srfi install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /test-snapshots/generated-docs
 /test-snapshots/test-out/
 /.direnv
+/tools/.spago
+/tools/output
+/vendor/

--- a/tools/spago.yaml
+++ b/tools/spago.yaml
@@ -1,0 +1,6 @@
+package:
+  name: tools
+  dependencies: [ console, node-execa, node-fs ]
+workspace:
+  package_set:
+    registry: 20.0.1

--- a/tools/src/Main.purs
+++ b/tools/src/Main.purs
@@ -1,0 +1,61 @@
+module Main where
+
+import Prelude
+
+import Control.Monad.Except (ExceptT(..), runExceptT)
+import Data.Bifunctor (bimap)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Effect.Aff (Aff, launchAff_)
+import Effect.Class (liftEffect)
+import Effect.Class.Console as Console
+import Node.FS.Sync as FS
+import Node.Library.Execa as Execa
+
+rmIf :: String -> Aff Unit
+rmIf p = liftEffect do
+  c <- FS.exists p
+  when c $
+    FS.rm' p { force: true, maxRetries: 1, recursive: true, retryDelay: 1 }
+
+fetchChezSrfi :: String -> ExceptT String Aff Unit
+fetchChezSrfi clonePath = ExceptT do
+  cloneExists <- liftEffect $ FS.exists clonePath
+  cloneOrFetch <- case cloneExists of
+    true -> do
+      Console.log "Fetching chez-srfi..."
+      spawned <- Execa.execa "git" [ "fetch", "origin" ] (_ { cwd = Just clonePath })
+      spawned.result
+    false -> do
+      Console.log "Cloning chez-srfi..."
+      spawned <- Execa.execa "git"
+        [ "clone", "https://github.com/arcfide/chez-srfi.git", clonePath ]
+        identity
+      spawned.result
+  pure $ bimap (_.message) (const unit) cloneOrFetch
+
+vendorChezSrfi :: String -> String -> ExceptT String Aff Unit
+vendorChezSrfi clonePath vendorPath = ExceptT do
+  Console.log "Vendoring chez-srfi..."
+  rmIf vendorPath
+  spawned <- Execa.execa "./install.chezscheme.sps" [ vendorPath ] (_ { cwd = Just clonePath })
+  bimap (_.message) (const unit) <$> spawned.result
+
+cleanChezSrfi :: String -> ExceptT String Aff Unit
+cleanChezSrfi clonePath = ExceptT do
+  Console.log "Cleaning chez-srfi..."
+  rmIf clonePath
+  pure (Right unit)
+
+main :: Effect Unit
+main = launchAff_ do
+  spawned <- runExceptT do
+    fetchChezSrfi "../chez-srfi"
+    vendorChezSrfi "../chez-srfi" "../vendor"
+    cleanChezSrfi "../chez-srfi"
+  case spawned of
+    Left message ->
+      Console.error $ "Failed: " <> message
+    Right _ ->
+      Console.log $ "Finished..."


### PR DESCRIPTION
Note that the vendoring process also adds compiled Scheme files which may be platform dependent. Right now, I just have it such that the vendor directory isn't tracked through Git though it may be desirable to do so.

When testing, the `vendor` directory can be added into the libdirs while executing `scheme` or copied over to the `output` directory. Likewise, the copying should be what's done for when `purescm` becomes an executable backend.

`purescm`-based projects in the future may make use of a package manager like Akku, and we should document that `chez-srfi` is already being vendored by the backend itself. Alternatively, maybe we could make it so that `chez-srfi` that we bundle exists under some `version`?