### PR TITLE
Integrate SRFIs to runtime

### DIFF
--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -21,7 +21,7 @@ import Data.String.Regex.Unsafe as R.Unsafe
 import Data.Tuple (Tuple(..), uncurry)
 import Data.Tuple as Tuple
 import Partial.Unsafe (unsafeCrashWith)
-import PureScript.Backend.Chez.Constants (libChezSchemePrefix, moduleForeign, moduleLib, runtimePrefix, scmPrefixed, undefinedSymbol)
+import PureScript.Backend.Chez.Constants (libChezSchemePrefix, moduleForeign, moduleLib, rtPrefixed, runtimePrefix, scmPrefixed, undefinedSymbol)
 import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezExpr, ChezImport(..), ChezImportSet(..), ChezLibrary, recordTypeAccessor, recordTypeCurriedConstructor, recordTypePredicate, recordTypeUncurriedConstructor)
 import PureScript.Backend.Chez.Syntax as S
 import PureScript.Backend.Optimizer.Convert (BackendModule, BackendBindingGroup)
@@ -172,14 +172,11 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
 
   Accessor e (GetProp i) ->
     S.runUncurriedFn
-      (S.Identifier $ scmPrefixed "hashtable-ref")
-      [ codegenExpr codegenEnv e
-      , S.StringExpr $ Json.stringify $ Json.fromString i
-      , S.Bool false
-      ]
+      (S.Identifier $ rtPrefixed "object-ref")
+      [ codegenExpr codegenEnv e, S.StringExpr $ Json.stringify $ Json.fromString i ]
   Accessor e (GetIndex i) ->
     S.runUncurriedFn
-      (S.Identifier $ scmPrefixed "vector-ref")
+      (S.Identifier $ rtPrefixed "array-ref")
       [ codegenExpr codegenEnv e, S.Integer $ wrap $ show i ]
   Accessor e (GetCtorField qi _ _ _ field _) ->
     S.recordAccessor (codegenExpr codegenEnv e) (flattenQualified currentModule qi) field

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -180,8 +180,8 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
       [ codegenExpr codegenEnv e, S.Integer $ wrap $ show i ]
   Accessor e (GetCtorField qi _ _ _ field _) ->
     S.recordAccessor (codegenExpr codegenEnv e) (flattenQualified currentModule qi) field
-  Update _ _ ->
-    S.Identifier "object-update"
+  Update e f ->
+    S.recordUpdate (codegenExpr codegenEnv e) (map (codegenExpr codegenEnv) <$> f)
 
   CtorSaturated qi _ _ _ xs ->
     S.runUncurriedFn

--- a/src/PureScript/Backend/Chez/Runtime.purs
+++ b/src/PureScript/Backend/Chez/Runtime.purs
@@ -66,6 +66,16 @@ createMakeObjectFn = makeExportedValue "make-object" $ S.List
 createObjectRefFn :: forall m. Monad m => MonadState (Array ChezExport) m => m ChezDefinition
 createObjectRefFn = makeExportedValue "object-ref" $ S.Identifier "srfi:125:hash-table-ref"
 
+createObjectSetFn :: forall m. Monad m => MonadState (Array ChezExport) m => m ChezDefinition
+createObjectSetFn = makeExportedValue "object-set!" $ S.Identifier "srfi:125:hash-table-set!"
+
+createObjectCopyFn :: forall m. Monad m => MonadState (Array ChezExport) m => m ChezDefinition
+createObjectCopyFn = makeExportedFunction "object-copy" (NEA.singleton "v") $ S.List
+  [ S.Identifier "srfi:125:hash-table-copy"
+  , S.Identifier "v"
+  , S.Bool true
+  ]
+
 importSRFI :: String -> ChezImport
 importSRFI srfi = ImportSet $ ImportPrefix
   ( ImportLibrary
@@ -98,6 +108,8 @@ runtimeModule = do
       , createArrayRefFn
       , createMakeObjectFn
       , createObjectRefFn
+      , createObjectSetFn
+      , createObjectCopyFn
       ]
   { "#!chezscheme": true
   , "#!r6rs": true

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -8,7 +8,7 @@ import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
-import Data.Tuple (Tuple)
+import Data.Tuple (Tuple(..))
 import PureScript.Backend.Chez.Constants (rtPrefixed, scmPrefixed)
 import PureScript.Backend.Optimizer.CoreFn (Prop(..))
 
@@ -155,3 +155,18 @@ recordTypeAccessor i field = i <> "-" <> field
 recordAccessor :: ChezExpr -> String -> String -> ChezExpr
 recordAccessor expr name field =
   runUncurriedFn (Identifier $ recordTypeAccessor name field) [ expr ]
+
+recordUpdate :: ChezExpr -> Array (Prop ChezExpr) -> ChezExpr
+recordUpdate h f = do
+  let
+    field :: Prop ChezExpr -> ChezExpr
+    field (Prop k v) =
+      List
+        [ Identifier $ rtPrefixed "object-set!"
+        , Identifier "$record"
+        , StringExpr $ Json.stringify $ Json.fromString k
+        , v
+        ]
+  Let false
+    (NonEmptyArray.singleton (Tuple "$record" (List [ Identifier $ rtPrefixed "object-copy", h ])))
+    (List $ [ Identifier $ scmPrefixed "begin" ] <> (field <$> f))

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -9,7 +9,7 @@ import Data.Array.NonEmpty as NonEmptyArray
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Data.Tuple (Tuple)
-import PureScript.Backend.Chez.Constants (scmPrefixed)
+import PureScript.Backend.Chez.Constants (rtPrefixed, scmPrefixed)
 import PureScript.Backend.Optimizer.CoreFn (Prop(..))
 
 type ChezLibrary =
@@ -122,30 +122,11 @@ app :: ChezExpr -> ChezExpr -> ChezExpr
 app f x = List [ f, x ]
 
 record :: Array (Prop ChezExpr) -> ChezExpr
-record r =
+record r = do
   let
-    field :: Prop ChezExpr -> ChezExpr
-    field (Prop k v) =
-      List
-        [ Identifier $ scmPrefixed "hashtable-set!"
-        , Identifier "$record"
-        , StringExpr $ Json.stringify $ Json.fromString k
-        , v
-        ]
-  in
-    List $
-      [ Identifier $ scmPrefixed "letrec*"
-      , List
-          [ List
-              [ Identifier "$record"
-              , List
-                  [ Identifier $ scmPrefixed "make-hashtable"
-                  , Identifier $ scmPrefixed "string-hash"
-                  , Identifier $ scmPrefixed "string=?"
-                  ]
-              ]
-          ]
-      ] <> (field <$> r) <> [ Identifier "$record" ]
+    field :: Prop ChezExpr -> Array ChezExpr
+    field (Prop k v) = [ StringExpr $ Json.stringify $ Json.fromString k, v ]
+  List $ [ Identifier $ rtPrefixed "make-object" ] <> Array.foldMap field r
 
 quote :: ChezExpr -> ChezExpr
 quote e = app (Identifier $ scmPrefixed "quote") e
@@ -154,7 +135,7 @@ eqQ :: ChezExpr -> ChezExpr -> ChezExpr
 eqQ x y = runUncurriedFn (Identifier $ scmPrefixed "eq?") [ x, y ]
 
 vector :: Array ChezExpr -> ChezExpr
-vector = List <<< Array.cons (Identifier $ scmPrefixed "vector")
+vector = List <<< Array.cons (Identifier $ rtPrefixed "make-array")
 
 recordTypeName :: String -> String
 recordTypeName i = i <> "$"

--- a/test-snapshots/spago.yaml
+++ b/test-snapshots/spago.yaml
@@ -7,6 +7,7 @@ package:
     - functions
     - partial
     - prelude
+    - record
     - refs
 workspace:
   package_set:
@@ -49,3 +50,14 @@ workspace:
       dependencies:
         - effect
         - prelude
+    record:
+      git: https://github.com/purescm/purescript-record.git
+      ref: 8a993da0d328f72167a4742e0e2a428a790510bc
+      dependencies: 
+        - functions
+        - prelude
+        - unsafe-coerce
+    unsafe-coerce:
+      git: https://github.com/purescm/purescript-unsafe-coerce.git
+      ref: 20dbd7797e985b631459b8dbd4072cf3096ee1da
+      dependencies: []

--- a/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.purs
@@ -1,4 +1,32 @@
+-- @inline Snapshot.Literals.Record.recordAccess never
+-- @inline Snapshot.Literals.Record.recordUpdate never
+-- @inline Snapshot.Literals.Record.recordAddField never
 module Snapshot.Literals.Record where
+
+import Prelude
+
+import Effect (Effect)
+import Prim.Row (class Lacks)
+import Record as Record
+import Test.Assert (assert)
+import Type.Proxy (Proxy(..))
 
 recordAccess :: forall a r. { fooBarBaz :: a | r } -> a
 recordAccess = _.fooBarBaz
+
+recordUpdate :: forall r. { fooBarBaz :: Int | r } -> { fooBarBaz :: Int | r }
+recordUpdate = _ { fooBarBaz = 10 }
+
+recordAddField :: forall r. Lacks "anotherField" r => { fooBarBaz :: Int | r } -> { fooBarBaz :: Int, anotherField :: Int | r }
+recordAddField = Record.insert (Proxy :: _ "anotherField") 42
+
+main :: Effect Unit
+main = do
+  let r = { fooBarBaz: 5 }
+  let s = recordUpdate r
+  let t = recordAddField s
+
+  assert $ recordAccess t == 10
+  assert $ t.anotherField == 42
+  assert $ recordAccess s == 10
+  assert $ recordAccess r == 5

--- a/test-snapshots/src/snapshots-output/Snapshot.ArrayIndex.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.ArrayIndex.ss
@@ -11,5 +11,5 @@
   (scm:define testAccessorGetIndex
     (scm:lambda (v0)
       (scm:cond
-        [(scm:fx=? (scm:vector-length v0) 1) (scm:vector-ref v0 0)]
+        [(scm:fx=? (scm:vector-length v0) 1) (rt:array-ref v0 0)]
         [scm:else 0]))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Comparison.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Comparison.ss
@@ -15,24 +15,24 @@
   (scm:define stringComparison
     (scm:lambda (x0)
       (scm:lambda (y1)
-        (scm:vector (scm:string=? x0 y1) (scm:not (scm:string=? x0 y1)) (scm:string<? x0 y1) (scm:string<=? x0 y1) (scm:string>=? x0 y1) (scm:string>? x0 y1)))))
+        (rt:make-array (scm:string=? x0 y1) (scm:not (scm:string=? x0 y1)) (scm:string<? x0 y1) (scm:string<=? x0 y1) (scm:string>=? x0 y1) (scm:string>? x0 y1)))))
 
   (scm:define numberComparison
     (scm:lambda (x0)
       (scm:lambda (y1)
-        (scm:vector (scm:fl=? x0 y1) (scm:not (scm:fl=? x0 y1)) (scm:fl<? x0 y1) (scm:fl<=? x0 y1) (scm:fl>=? x0 y1) (scm:fl>? x0 y1)))))
+        (rt:make-array (scm:fl=? x0 y1) (scm:not (scm:fl=? x0 y1)) (scm:fl<? x0 y1) (scm:fl<=? x0 y1) (scm:fl>=? x0 y1) (scm:fl>? x0 y1)))))
 
   (scm:define integerComparison
     (scm:lambda (x0)
       (scm:lambda (y1)
-        (scm:vector (scm:fx=? x0 y1) (scm:not (scm:fx=? x0 y1)) (scm:fx<? x0 y1) (scm:fx<=? x0 y1) (scm:fx>=? x0 y1) (scm:fx>? x0 y1)))))
+        (rt:make-array (scm:fx=? x0 y1) (scm:not (scm:fx=? x0 y1)) (scm:fx<? x0 y1) (scm:fx<=? x0 y1) (scm:fx>=? x0 y1) (scm:fx>? x0 y1)))))
 
   (scm:define charComparison
     (scm:lambda (x0)
       (scm:lambda (y1)
-        (scm:vector (scm:char=? x0 y1) (scm:not (scm:char=? x0 y1)) (scm:char<? x0 y1) (scm:char<=? x0 y1) (scm:char>=? x0 y1) (scm:char>? x0 y1)))))
+        (rt:make-array (scm:char=? x0 y1) (scm:not (scm:char=? x0 y1)) (scm:char<? x0 y1) (scm:char<=? x0 y1) (scm:char>=? x0 y1) (scm:char>? x0 y1)))))
 
   (scm:define booleanComparison
     (scm:lambda (x0)
       (scm:lambda (y1)
-        (scm:vector (scm:boolean=? x0 y1) (scm:not (scm:boolean=? x0 y1)) (rt:boolean<? x0 y1) (rt:boolean<=? x0 y1) (rt:boolean>=? x0 y1) (rt:boolean>? x0 y1))))))
+        (rt:make-array (scm:boolean=? x0 y1) (scm:not (scm:boolean=? x0 y1)) (rt:boolean<? x0 y1) (rt:boolean<=? x0 y1) (rt:boolean>=? x0 y1) (rt:boolean>? x0 y1))))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Function.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Function.ss
@@ -12,7 +12,7 @@
   (scm:define f
     (scm:lambda (x0)
       (scm:lambda (y1)
-        (scm:vector x0 y1 x0 y1 x0))))
+        (rt:make-array x0 y1 x0 y1 x0))))
 
   (scm:define g
     (scm:lambda (x0)

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -3,11 +3,44 @@
 (library
   (Snapshot.Literals.Record lib)
   (export
-    recordAccess)
+    insert
+    main
+    recordAccess
+    recordAddField
+    recordUpdate)
   (import
     (prefix (chezscheme) scm:)
-    (prefix (purs runtime lib) rt:))
+    (prefix (purs runtime lib) rt:)
+    (prefix (Record lib) Record.)
+    (prefix (Test.Assert lib) Test.Assert.)
+    (prefix (Type.Proxy lib) Type.Proxy.))
+
+  (scm:define insert
+    (((Record.insert (rt:make-object "reflectSymbol" (scm:lambda (_)
+      "anotherField"))) (scm:gensym "purs-undefined")) (scm:gensym "purs-undefined")))
+
+  (scm:define recordUpdate
+    (scm:lambda (v0)
+      (scm:let ([$record (rt:object-copy v0)])
+        (scm:begin (rt:object-set! $record "fooBarBaz" 10)))))
+
+  (scm:define recordAddField
+    (scm:lambda (_)
+      ((insert Type.Proxy.Proxy) 42)))
 
   (scm:define recordAccess
     (scm:lambda (v0)
-      (rt:object-ref v0 "fooBarBaz"))))
+      (rt:object-ref v0 "fooBarBaz")))
+
+  (scm:define main
+    (scm:let*
+      ([r0 (rt:make-object "fooBarBaz" 5)]
+       [s1 (recordUpdate r0)]
+       [t2 ((recordAddField (scm:gensym "purs-undefined")) s1)]
+       [_3 (Test.Assert.assert (scm:fx=? (recordAccess t2) 10))])
+        (scm:lambda ()
+          (scm:let*
+            ([_ (_3)]
+             [_ ((Test.Assert.assert (scm:fx=? (rt:object-ref t2 "anotherField") 42)))]
+             [_ ((Test.Assert.assert (scm:fx=? (recordAccess s1) 10)))])
+              ((Test.Assert.assert (scm:fx=? (recordAccess r0) 5))))))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -10,4 +10,4 @@
 
   (scm:define recordAccess
     (scm:lambda (v0)
-      (scm:hashtable-ref v0 "fooBarBaz" #f))))
+      (rt:object-ref v0 "fooBarBaz"))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.ss
@@ -21,10 +21,10 @@
     "string")
 
   (scm:define record2
-    (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) (scm:hashtable-set! $record "foo" "bar") $record))
+    (rt:make-object "foo" "bar"))
 
   (scm:define record
-    (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) $record))
+    (rt:make-object))
 
   (scm:define number
     2.0)
@@ -42,7 +42,7 @@
     #t)
 
   (scm:define array2
-    (scm:vector 1 2 3))
+    (rt:make-array 1 2 3))
 
   (scm:define array
-    (scm:vector)))
+    (rt:make-array)))

--- a/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
@@ -13,7 +13,7 @@
 
   (scm:define testCase
     (scm:lambda (dictRing0)
-      (scm:hashtable-ref ((scm:hashtable-ref dictRing0 "Semiring0" #f) (scm:gensym "purs-undefined")) "add" #f)))
+      (rt:object-ref ((rt:object-ref dictRing0 "Semiring0") (scm:gensym "purs-undefined")) "add")))
 
   (scm:define main
     (Test.Assert.assert (scm:fx=? (((testCase Data.Ring.ringInt) 1) 1) 2))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
@@ -104,11 +104,11 @@
             (scm:string-append ((scm:hashtable-ref dictNormal0 "normal" #f) a2) ((scm:hashtable-ref dictNormal11 "normal" #f) b3)))))))
 
   (scm:define instanceName$p
-    (scm:letrec* (($record (scm:make-hashtable scm:string-hash scm:string=?))) (scm:hashtable-set! $record "normal" (scm:lambda (v0)
+    (rt:make-object "normal" (scm:lambda (v0)
       (scm:cond
         [(F1? v0) "F1"]
         [(F2? v0) "F2"]
-        [scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))]))) $record))
+        [scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))]))))
 
   (scm:define useInstance
     "F1F2")

--- a/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
@@ -94,14 +94,14 @@
 
   (scm:define normal
     (scm:lambda (dict0)
-      (scm:hashtable-ref dict0 "normal" #f)))
+      (rt:object-ref dict0 "normal")))
 
   (scm:define useNormal
     (scm:lambda (dictNormal0)
       (scm:lambda (dictNormal11)
         (scm:lambda (a2)
           (scm:lambda (b3)
-            (scm:string-append ((scm:hashtable-ref dictNormal0 "normal" #f) a2) ((scm:hashtable-ref dictNormal11 "normal" #f) b3)))))))
+            (scm:string-append ((rt:object-ref dictNormal0 "normal") a2) ((rt:object-ref dictNormal11 "normal") b3)))))))
 
   (scm:define instanceName$p
     (rt:make-object "normal" (scm:lambda (v0)
@@ -115,11 +115,11 @@
 
   (scm:define ignore
     (scm:lambda (dict0)
-      (scm:hashtable-ref dict0 "ignore" #f)))
+      (rt:object-ref dict0 "ignore")))
 
   (scm:define useClass
     (scm:lambda (dictClassName$p0)
-      (scm:hashtable-ref dictClassName$p0 "ignore" #f)))
+      (rt:object-ref dictClassName$p0 "ignore")))
 
   (scm:define foo$poo
     "foo'oo")
@@ -144,8 +144,8 @@
 
   (scm:define classMember$p
     (scm:lambda (dict0)
-      (scm:hashtable-ref dict0 "classMember'" #f)))
+      (rt:object-ref dict0 "classMember'")))
 
   (scm:define useMember
     (scm:lambda (dictClassMember0)
-      (scm:hashtable-ref dictClassMember0 "classMember'" #f))))
+      (rt:object-ref dictClassMember0 "classMember'"))))

--- a/vendor/purs/runtime/srfi/private/check-arg.sls
+++ b/vendor/purs/runtime/srfi/private/check-arg.sls
@@ -1,0 +1,23 @@
+#!r6rs
+;; Copyright 2010 Derick Eddington.  My MIT-style license is in the file named
+;; LICENSE from the original collection this file is distributed with.
+
+;; If your Scheme system doesn't have a stack-tracing debugger, you can change
+;; this to use the version which actually does check.
+
+(library (purs runtime srfi private check-arg)
+  (export
+    check-arg)
+  (import
+    (rnrs))
+
+#;(define (check-arg pred val who)
+    (if (pred val)
+      val
+      (assertion-violation #F "check-arg failed" who pred val)))
+
+  (define-syntax check-arg
+    (syntax-rules ()
+      ((_ pred val who)
+       val)))
+)

--- a/vendor/purs/runtime/srfi/private/define-values.chezscheme.sls
+++ b/vendor/purs/runtime/srfi/private/define-values.chezscheme.sls
@@ -1,0 +1,3 @@
+(library (purs runtime srfi private define-values)
+  (export define-values)
+  (import (chezscheme)))

--- a/vendor/purs/runtime/srfi/private/vanish.sls
+++ b/vendor/purs/runtime/srfi/private/vanish.sls
@@ -1,0 +1,35 @@
+#!r6rs
+;; Copyright 2009 Derick Eddington.  My MIT-style license is in the file named
+;; LICENSE from the original collection this file is distributed with.
+
+(library (purs runtime srfi private vanish)
+  (export
+    vanish-define)
+  (import
+    (rnrs)
+    (for (only (rnrs base) begin) (meta -1)))
+
+  (define-syntax vanish-define
+    (lambda (stx)
+      (syntax-case stx ()
+        ((_ def (vanish ...))
+         (for-all identifier? #'(def vanish ...))
+         #'(make-vanish-define (syntax def) (syntax vanish) ...)))))
+
+  (define (make-vanish-define def . to-vanish)
+    (lambda (stx)
+      (define (vanish? id)
+        (memp (lambda (x) (free-identifier=? id x))
+              to-vanish))
+      (syntax-case stx ()
+        ((_ name . _)
+         (and (identifier? #'name)
+              (vanish? #'name))
+         #'(begin))
+        ((_ (name . _) . _)
+         (and (identifier? #'name)
+              (vanish? #'name))
+         #'(begin))
+        ((_ . r)
+         (cons def #'r)))))
+)


### PR DESCRIPTION
This PR integrates the added SRFIs to the runtime. Arrays and records are now represented by SRFI 214 and SRFI 125 respectively. This is the second half of #135.