### PR TITLE
Export only explicitly exported identifiers

### DIFF
--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -46,11 +46,12 @@ codegenModule { name, bindings, exports, imports, foreign: foreign_ } =
 
     exports' :: Array ChezExport
     exports' =
-      let exportedIdentifiers = flip Array.filter definitions case _ of
-            Define i _ -> Set.member (Ident i) exports
-            DefineRecordType i _ -> Set.member (Ident i) exports
-            DefinePredicate i _ -> Set.member (Ident i) exports
-          exportedForeignIdentifiers = Set.intersection foreign_ exports
+      let
+        exportedIdentifiers = flip Array.filter definitions case _ of
+          Define i _ -> Set.member (Ident i) exports
+          DefineRecordType i _ -> Set.member (Ident i) exports
+          DefinePredicate i _ -> Set.member (Ident i) exports
+        exportedForeignIdentifiers = Set.intersection foreign_ exports
       in
         map ExportIdentifier
           $ Array.sort

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -45,17 +45,17 @@ codegenModule { name, bindings, exports, imports, foreign: foreign_ } =
       codegenTopLevelBindingGroup codegenEnv <$> bindings
 
     exports' :: Array ChezExport
-    exports' = map ExportIdentifier
-      $ Array.sort
-      $ Array.concatMap definitionIdentifiers exportedIdentifiers
-          <> map coerce (Array.fromFoldable foreign_)
-      where
-        exportedIdentifiers = Array.filter isExported definitions
-        isExported = case _ of
-          Define i _ -> Set.member (Ident i) exports
-          DefineRecordType i _ -> Set.member (Ident i) exports
-          DefinePredicate i _ -> Set.member (Ident i) exports
-
+    exports' =
+      let exportedIdentifiers = flip Array.filter definitions case _ of
+            Define i _ -> Set.member (Ident i) exports
+            DefineRecordType i _ -> Set.member (Ident i) exports
+            DefinePredicate i _ -> Set.member (Ident i) exports
+          exportedForeignIdentifiers = Set.intersection foreign_ exports
+      in
+        map ExportIdentifier
+          $ Array.sort
+          $ Array.concatMap definitionIdentifiers exportedIdentifiers
+              <> map coerce (Array.fromFoldable exportedForeignIdentifiers)
 
     pursImports :: Array ChezImport
     pursImports = Array.fromFoldable imports <#> \importedModule ->

--- a/src/PureScript/Backend/Chez/Printer.purs
+++ b/src/PureScript/Backend/Chez/Printer.purs
@@ -251,7 +251,8 @@ printDefinition = case _ of
       (recordTypePredicate ident)
       fields
   DefinePredicate ident expr ->
-    printNamedIndentedList (D.words [ D.text $ scmPrefixed "define", D.text (recordTypePredicate ident) ])
+    printNamedIndentedList
+      (D.words [ D.text $ scmPrefixed "define", D.text (recordTypePredicate ident) ])
       $ printChezExpr expr
 
 printChezExpr :: ChezExpr -> Doc Void

--- a/src/PureScript/Backend/Chez/Printer.purs
+++ b/src/PureScript/Backend/Chez/Printer.purs
@@ -90,6 +90,7 @@ escapeIdentifiers lib = lib
   escapeDefinition = case _ of
     Define i expr -> Define (escapeIdent i) $ escapeExpr expr
     DefineRecordType i fields -> DefineRecordType (escapeIdent i) $ map escapeIdent fields
+    DefinePredicate i expr -> DefinePredicate (escapeIdent i) $ escapeExpr expr
 
   escapeExpr = case _ of
     Identifier i -> Identifier $ escapeIdent i
@@ -249,6 +250,9 @@ printDefinition = case _ of
       (recordTypeUncurriedConstructor ident)
       (recordTypePredicate ident)
       fields
+  DefinePredicate ident expr ->
+    printNamedIndentedList (D.words [ D.text $ scmPrefixed "define", D.text (recordTypePredicate ident) ])
+      $ printChezExpr expr
 
 printChezExpr :: ChezExpr -> Doc Void
 printChezExpr e = case e of

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -77,6 +77,7 @@ type LibraryBody =
 data ChezDefinition
   = Define String ChezExpr
   | DefineRecordType String (Array String)
+  | DefinePredicate String ChezExpr
 
 newtype LiteralDigit = LiteralDigit String
 

--- a/test-snapshots/src/snapshots-input/Snapshot.Export.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Export.purs
@@ -1,6 +1,10 @@
-module Snapshot.Export (exported, Test) where
+module Snapshot.Export (exported, Test, exportedForeign) where
 
 exported :: Test
 exported = Baz 1 2
 
-data Test = Foo Int | Bar | Baz Int Int
+data Test = Foo | Bar Int | Baz Int Int
+
+foreign import exportedForeign :: Int
+
+foreign import internalForeign :: Int

--- a/test-snapshots/src/snapshots-input/Snapshot.Export.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Export.purs
@@ -1,0 +1,6 @@
+module Snapshot.Export (exported, Test) where
+
+exported :: Test
+exported = Baz 1 2
+
+data Test = Foo Int | Bar | Baz Int Int

--- a/test-snapshots/src/snapshots-input/Snapshot.Export.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Export.purs
@@ -1,9 +1,19 @@
-module Snapshot.Export (exported, Test, exportedForeign) where
+module Snapshot.Export (exported, foo, Foo, bar, Bar, Test, exportedForeign) where
+
+data Foo = Foo
+
+data Bar = Bar Int Int
+
+data Test = Zero | One Int | Two Int Int
 
 exported :: Test
-exported = Baz 1 2
+exported = Two 1 2
 
-data Test = Foo | Bar Int | Baz Int Int
+foo :: Foo
+foo = Foo
+
+bar :: Bar
+bar = Bar 1 2
 
 foreign import exportedForeign :: Int
 

--- a/test-snapshots/src/snapshots-input/Snapshot.Export.ss
+++ b/test-snapshots/src/snapshots-input/Snapshot.Export.ss
@@ -1,0 +1,6 @@
+(library (Snapshot.Export foreign) 
+  (export exportedForeign) 
+  (import (chezscheme))
+  
+  (define exportedForeign 1)
+  (define internalForeign 2))

--- a/test-snapshots/src/snapshots-output/Snapshot.Export.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Export.ss
@@ -1,0 +1,20 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Export lib)
+  (export
+    exported)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (purs runtime lib) rt:))
+
+  (scm:define-record-type (Baz$ Baz* Baz?)
+    (scm:fields (scm:immutable value0 Baz-value0) (scm:immutable value1 Baz-value1)))
+
+  (scm:define Baz
+    (scm:lambda (value0)
+      (scm:lambda (value1)
+        (Baz* value0 value1))))
+
+  (scm:define exported
+    (Baz* 1 2)))

--- a/test-snapshots/src/snapshots-output/Snapshot.Export.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Export.ss
@@ -3,10 +3,12 @@
 (library
   (Snapshot.Export lib)
   (export
-    exported)
+    exported
+    exportedForeign)
   (import
     (prefix (chezscheme) scm:)
-    (prefix (purs runtime lib) rt:))
+    (prefix (purs runtime lib) rt:)
+    (Snapshot.Export foreign))
 
   (scm:define-record-type (Baz$ Baz* Baz?)
     (scm:fields (scm:immutable value0 Baz-value0) (scm:immutable value1 Baz-value1)))

--- a/test-snapshots/src/snapshots-output/Snapshot.Export.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Export.ss
@@ -3,20 +3,43 @@
 (library
   (Snapshot.Export lib)
   (export
+    bar
     exported
-    exportedForeign)
+    exportedForeign
+    foo)
   (import
     (prefix (chezscheme) scm:)
     (prefix (purs runtime lib) rt:)
     (Snapshot.Export foreign))
 
-  (scm:define-record-type (Baz$ Baz* Baz?)
-    (scm:fields (scm:immutable value0 Baz-value0) (scm:immutable value1 Baz-value1)))
+  (scm:define-record-type (Two$ Two* Two?)
+    (scm:fields (scm:immutable value0 Two-value0) (scm:immutable value1 Two-value1)))
 
-  (scm:define Baz
+  (scm:define Two
     (scm:lambda (value0)
       (scm:lambda (value1)
-        (Baz* value0 value1))))
+        (Two* value0 value1))))
+
+  (scm:define Foo
+    (scm:quote Foo))
+
+  (scm:define Foo?
+    (scm:lambda (v)
+      (scm:eq? (scm:quote Foo) v)))
+
+  (scm:define-record-type (Bar$ Bar* Bar?)
+    (scm:fields (scm:immutable value0 Bar-value0) (scm:immutable value1 Bar-value1)))
+
+  (scm:define Bar
+    (scm:lambda (value0)
+      (scm:lambda (value1)
+        (Bar* value0 value1))))
+
+  (scm:define foo
+    Foo)
 
   (scm:define exported
-    (Baz* 1 2)))
+    (Two* 1 2))
+
+  (scm:define bar
+    (Bar* 1 2)))

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -3,7 +3,6 @@
 (library
   (Snapshot.Literals.Record lib)
   (export
-    insert
     main
     recordAccess
     recordAddField


### PR DESCRIPTION
Only export identifiers set in the exports list. This fixes #106.

We filter the identifiers after code generation which means we need to keep the original purs identifiers in the `ChezDefinition`. The only case where we don't keep track of the original identifier name in the `ChezDefinition` is the zero arity constructor for which we generate a predicate. So I added a new `ChezDefinition` for the predicate and then delay the generation of the predicate identifier name until the `Printer`.