### PR TITLE
Fix codegen for floats

### DIFF
--- a/test-snapshots/src/snapshots-input/Snapshot.Literals.Number.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Literals.Number.purs
@@ -1,0 +1,12 @@
+module Snapshot.Literals.Number where
+
+import Prelude
+
+nan :: Number
+nan = 0.0 / 0.0
+
+plusInfinity :: Number
+plusInfinity = 1.0 / 0.0
+
+minusInfinity :: Number
+minusInfinity = -1.0 / 0.0

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Number.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Number.ss
@@ -1,0 +1,20 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Literals.Number lib)
+  (export
+    minusInfinity
+    nan
+    plusInfinity)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (purs runtime lib) rt:))
+
+  (scm:define plusInfinity
+    +inf.0)
+
+  (scm:define nan
+    +nan.0)
+
+  (scm:define minusInfinity
+    -inf.0))


### PR DESCRIPTION
Fixes the situation where the backend-optimizer evaluates an expression to JS Infinity, -Infinity or NaN such that those values appear literally in the scheme source. We just generate the correct counterparts for those values in scheme.

Fixes #144 