### PR TITLE
Update backend-optimizer

### DIFF
--- a/spago.yaml
+++ b/spago.yaml
@@ -48,7 +48,7 @@ workspace:
   extra_packages:
     backend-optimizer:
       git: https://github.com/aristanetworks/purescript-backend-optimizer
-      ref: c11f1e9f411ebbb4045734f7429578972836d60c
+      ref: 21b0f9f28c05cc642757802625f1e4a00077dc43
       dependencies:
         - aff
         - ansi

--- a/test-snapshots/src/snapshots-input/Snapshot.Import.Constructor.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Import.Constructor.purs
@@ -1,0 +1,3 @@
+module Snapshot.Import.Constructor where
+
+data Foo = Foo

--- a/test-snapshots/src/snapshots-input/Snapshot.Import.Impl.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Import.Impl.purs
@@ -4,3 +4,5 @@ foreign import addImpl :: Int -> Int -> Int
 
 fortyTwo :: Int
 fortyTwo = addImpl 21 21
+
+data Product = Product Int Int

--- a/test-snapshots/src/snapshots-input/Snapshot.Import.Product.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Import.Product.purs
@@ -1,0 +1,3 @@
+module Snapshot.Import.Product where
+
+data Product = Product Int Int

--- a/test-snapshots/src/snapshots-input/Snapshot.Import.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Import.purs
@@ -1,6 +1,14 @@
 module Snapshot.Import where
 
 import Snapshot.Import.Impl as I
+import Snapshot.Import.Product
+import Snapshot.Import.Constructor
 
 fortyThree :: Int
 fortyThree = I.addImpl 21 22
+
+fst :: Product -> Int
+fst (Product x _) = x
+
+foo :: Foo
+foo = Foo

--- a/test-snapshots/src/snapshots-output/Snapshot.Import.Constructor.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Import.Constructor.ss
@@ -1,0 +1,17 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Import.Constructor lib)
+  (export
+    Foo
+    Foo?)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (purs runtime lib) rt:))
+
+  (scm:define Foo
+    (scm:quote Foo))
+
+  (scm:define Foo?
+    (scm:lambda (v)
+      (scm:eq? (scm:quote Foo) v))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Import.Product.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Import.Product.ss
@@ -1,19 +1,16 @@
 #!r6rs
 #!chezscheme
 (library
-  (Snapshot.Import.Impl lib)
+  (Snapshot.Import.Product lib)
   (export
     Product
     Product*
     Product-value0
     Product-value1
-    Product?
-    addImpl
-    fortyTwo)
+    Product?)
   (import
     (prefix (chezscheme) scm:)
-    (prefix (purs runtime lib) rt:)
-    (Snapshot.Import.Impl foreign))
+    (prefix (purs runtime lib) rt:))
 
   (scm:define-record-type (Product$ Product* Product?)
     (scm:fields (scm:immutable value0 Product-value0) (scm:immutable value1 Product-value1)))
@@ -21,7 +18,4 @@
   (scm:define Product
     (scm:lambda (value0)
       (scm:lambda (value1)
-        (Product* value0 value1))))
-
-  (scm:define fortyTwo
-    ((addImpl 21) 21)))
+        (Product* value0 value1)))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Import.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Import.ss
@@ -3,11 +3,22 @@
 (library
   (Snapshot.Import lib)
   (export
-    fortyThree)
+    foo
+    fortyThree
+    fst)
   (import
     (prefix (chezscheme) scm:)
     (prefix (purs runtime lib) rt:)
-    (prefix (Snapshot.Import.Impl lib) Snapshot.Import.Impl.))
+    (prefix (Snapshot.Import.Constructor lib) Snapshot.Import.Constructor.)
+    (prefix (Snapshot.Import.Impl lib) Snapshot.Import.Impl.)
+    (prefix (Snapshot.Import.Product lib) Snapshot.Import.Product.))
+
+  (scm:define fst
+    (scm:lambda (v0)
+      (Snapshot.Import.Product.Product-value0 v0)))
 
   (scm:define fortyThree
-    ((Snapshot.Import.Impl.addImpl 21) 22)))
+    ((Snapshot.Import.Impl.addImpl 21) 22))
+
+  (scm:define foo
+    Snapshot.Import.Constructor.Foo))

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -116,7 +116,7 @@ runSnapshotTests { accept, filter } = do
       coreFnModules # buildModules
         { directives
         , foreignSemantics: coreForeignSemantics -- no chez scheme specific foreign semantics yet
-        , onCodegenModule: \_ (Module { name: ModuleName name, path }) backend -> do
+        , onCodegenModule: \_ (Module { name: ModuleName name, path }) backend _ -> do
             let
               formatted =
                 Dodo.print plainText Dodo.twoSpaces
@@ -147,6 +147,7 @@ runSnapshotTests { accept, filter } = do
             let padding = power " " (SCU.length total - SCU.length index)
             Console.log $ "[" <> padding <> index <> " of " <> total <> "] Building " <> unwrap name
             pure coreFnMod
+        , traceIdents: Set.empty
         }
       outputModules <- liftEffect $ Ref.read outputRef
       results <- forWithIndex outputModules \name ({ formatted, failsWith, hasMain }) -> do


### PR DESCRIPTION
Updates the backend-optimizer to the latest version. This fixes a few things, mainly that constructor references add imports correctly. I've added a few cases to the snapshots.