### PR TITLE
Fix array-ref and array-length references

### DIFF
--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -371,7 +371,7 @@ codegenPrimOp codegenEnv@{ currentModule } = case _ of
       OpNumberNegate ->
         S.List [ S.Identifier $ scmPrefixed "fl-", x' ]
       OpArrayLength ->
-        S.List [ S.Identifier $ scmPrefixed "vector-length", x' ]
+        S.List [ S.Identifier $ rtPrefixed "array-length", x' ]
       OpIsTag qi ->
         S.app
           (S.Identifier $ S.recordTypePredicate $ flattenQualified currentModule qi)

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -409,7 +409,7 @@ codegenPrimOp codegenEnv@{ currentModule } = case _ of
     in
       case o of
         OpArrayIndex ->
-          S.List [ S.Identifier $ scmPrefixed "vector-ref", x', y' ]
+          S.List [ S.Identifier $ rtPrefixed "array-ref", x', y' ]
         OpBooleanAnd ->
           S.List [ S.Identifier $ scmPrefixed "and", x', y' ]
         OpBooleanOr ->

--- a/src/PureScript/Backend/Chez/Runtime.purs
+++ b/src/PureScript/Backend/Chez/Runtime.purs
@@ -48,6 +48,9 @@ createMakeArrayFn = makeExportedValue "make-array" $ S.Identifier "srfi:214:flex
 createArrayRefFn :: forall m. Monad m => MonadState (Array ChezExport) m => m ChezDefinition
 createArrayRefFn = makeExportedValue "array-ref" $ S.Identifier "srfi:214:flexvector-ref"
 
+createArrayLengthFn :: forall m. Monad m => MonadState (Array ChezExport) m => m ChezDefinition
+createArrayLengthFn = makeExportedValue "array-length" $ S.Identifier "srfi:214:flexvector-length"
+
 createMakeObjectFn :: forall m. Monad m => MonadState (Array ChezExport) m => m ChezDefinition
 createMakeObjectFn = makeExportedValue "make-object" $ S.List
   [ S.Identifier $ scmPrefixed "lambda"
@@ -106,6 +109,7 @@ runtimeModule = do
       , makeBooleanComparison "<?"
       , createMakeArrayFn
       , createArrayRefFn
+      , createArrayLengthFn
       , createMakeObjectFn
       , createObjectRefFn
       , createObjectSetFn

--- a/test-snapshots/src/snapshots-output/Snapshot.ArrayIndex.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.ArrayIndex.ss
@@ -11,5 +11,5 @@
   (scm:define testAccessorGetIndex
     (scm:lambda (v0)
       (scm:cond
-        [(scm:fx=? (scm:vector-length v0) 1) (rt:array-ref v0 0)]
+        [(scm:fx=? (rt:array-length v0) 1) (rt:array-ref v0 0)]
         [scm:else 0]))))


### PR DESCRIPTION
* Fixes array indexing to reference the correct runtime symbol
* Fixes `array-length` reference and adds that to the runtime