### PR TITLE
Add vendor directory to the libdir instead of copying all the files

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -51,7 +51,7 @@ import PureScript.Backend.Optimizer.CoreFn (Comment(..), Module(..), ModuleName(
 import PureScript.Backend.Optimizer.Directives (parseDirectiveFile)
 import PureScript.Backend.Optimizer.Directives.Defaults (defaultDirectives)
 import PureScript.Backend.Optimizer.Semantics.Foreign (coreForeignSemantics)
-import Test.Utils (bufferToUTF8, canRunMain, copyFile, coreFnModulesFromOutput, cpr, execWithStdin, loadModuleMain, mkdirp, spawnFromParent)
+import Test.Utils (bufferToUTF8, canRunMain, copyFile, coreFnModulesFromOutput, execWithStdin, loadModuleMain, mkdirp, spawnFromParent)
 
 type TestArgs =
   { accept :: Boolean
@@ -85,7 +85,7 @@ main = do
 runSnapshotTests :: TestArgs -> Aff Unit
 runSnapshotTests { accept, filter } = do
   currentDirectory <- liftEffect Process.cwd
-  let vendorDirectory = Path.concat [ currentDirectory, "vendor", "purs" ]
+  let vendorDirectory = Path.concat [ currentDirectory, "vendor" ]
   liftEffect $ Process.chdir $ Path.concat [ "test-snapshots" ]
   spawnFromParent "spago" [ "build", "--purs-args", "-g corefn" ]
   snapshotDir <- liftEffect Process.cwd
@@ -103,7 +103,6 @@ runSnapshotTests { accept, filter } = do
   let runtimeFilePath = Path.concat [ runtimePath, moduleLib <> schemeExt ]
   let runtimeContents = Dodo.print plainText Dodo.twoSpaces $ P.printLibrary $ runtimeModule
   FS.writeTextFile UTF8 runtimeFilePath runtimeContents
-  cpr vendorDirectory testOut
   coreFnModulesFromOutput "output" filter >>= case _ of
     Left errors -> do
       for_ errors \(Tuple filePath err) -> do
@@ -156,7 +155,7 @@ runSnapshotTests { accept, filter } = do
           runAcceptedTest = do
             schemeFile <- liftEffect $ Path.resolve [ testOut, name ] $ moduleLib <> schemeExt
             result <- loadModuleMain
-              { libdir: testOut
+              { libdir: vendorDirectory <> ":" <> testOut
               , scheme: schemeBin
               , hasMain
               , modulePath: schemeFile

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -110,8 +110,6 @@ runSnapshotTests { accept, filter } = do
       liftEffect $ Process.exit 1
     Right coreFnModules -> do
       let { directives } = parseDirectiveFile defaultDirectives
-      -- No runtime .ss files needed yet
-      -- copyFile (Path.concat [ "..", "..", "runtime.js" ]) (Path.concat [ testOut, "runtime.js" ])
       coreFnModules # buildModules
         { directives
         , foreignSemantics: coreForeignSemantics -- no chez scheme specific foreign semantics yet

--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -76,15 +76,6 @@ bufferToUTF8 = liftEffect <<< map (ImmutableBuffer.toString UTF8) <<< freeze
 mkdirp :: FilePath -> Aff Unit
 mkdirp path = FS.mkdir' path { recursive: true, mode: mkPerms Perms.all Perms.all Perms.all }
 
-cpr :: FilePath -> FilePath -> Aff Unit
-cpr from to = do
-  spawned <- execa "cp" [ "-r", from, to ] identity
-  spawned.result >>= case _ of
-    Left e ->
-      Console.error e.message
-    Right _ ->
-      pure unit
-
 loadModuleMain
   :: { libdir :: FilePath
      , scheme :: String


### PR DESCRIPTION
This refactors the test suite so that it adds the vendor directory to the libdir instead of copying the entire directory over to the test output directory. This is in line with the main CLI.

Also remove comment about runtime files. 