### PR TITLE
Add a common builder helper

### DIFF
--- a/src/PureScript/Backend/Chez/Builder.purs
+++ b/src/PureScript/Backend/Chez/Builder.purs
@@ -1,0 +1,95 @@
+module PureScript.Backend.Chez.Builder where
+
+import Prelude
+
+import Control.Monad.Cont.Trans (lift)
+import Control.Monad.Except (ExceptT(..), runExceptT)
+import Control.Parallel (parTraverse)
+import Data.Argonaut as Json
+import Data.Array.NonEmpty (NonEmptyArray)
+import Data.Array.NonEmpty as NonEmptyArray
+import Data.Bifunctor (lmap)
+import Data.Compactable (separate)
+import Data.Either (Either(..))
+import Data.Foldable (foldl, for_)
+import Data.Lazy as Lazy
+import Data.List (List)
+import Data.Maybe (maybe)
+import Data.Set as Set
+import Data.Set.NonEmpty as NonEmptySet
+import Data.Tuple (Tuple(..))
+import Effect.Aff (Aff)
+import Effect.Class (liftEffect)
+import Effect.Class.Console as Console
+import Node.Encoding (Encoding(..))
+import Node.FS.Aff as FS
+import Node.Glob.Basic (expandGlobs)
+import Node.Path (FilePath)
+import Node.Process as Process
+import PureScript.Backend.Optimizer.Builder (BuildEnv, buildModules)
+import PureScript.Backend.Optimizer.Convert (BackendModule, OptimizationSteps)
+import PureScript.Backend.Optimizer.CoreFn (Ann, Module, ModuleName(..))
+import PureScript.Backend.Optimizer.CoreFn.Json (decodeModule)
+import PureScript.Backend.Optimizer.CoreFn.Sort (emptyPull, pullResult, resumePull, sortModules)
+import PureScript.Backend.Optimizer.Directives (parseDirectiveFile)
+import PureScript.Backend.Optimizer.Directives.Defaults (defaultDirectives)
+import PureScript.Backend.Optimizer.Semantics.Foreign (coreForeignSemantics)
+
+basicBuildMain
+  :: { coreFnDirectory :: FilePath
+     , coreFnGlobs :: NonEmptyArray String
+     , onCodegenModule :: BuildEnv -> Module Ann -> BackendModule -> OptimizationSteps -> Aff Unit
+     , onPrepareModule :: BuildEnv -> Module Ann -> Aff (Module Ann)
+     }
+  -> Aff Unit
+basicBuildMain options = do
+  coreFnModulesFromOutput options.coreFnDirectory options.coreFnGlobs >>= case _ of
+    Left errors -> do
+      for_ errors \(Tuple filePath err) -> do
+        Console.error $ filePath <> " " <> err
+      liftEffect $ Process.exit 1
+    Right coreFnModules -> do
+      let { directives } = parseDirectiveFile defaultDirectives
+      coreFnModules # buildModules
+        { directives
+        , foreignSemantics: coreForeignSemantics
+        , onCodegenModule: options.onCodegenModule
+        , onPrepareModule: options.onPrepareModule
+        , traceIdents: Set.empty
+        }
+
+coreFnModulesFromOutput
+  :: String
+  -> NonEmptyArray String
+  -> Aff (Either (NonEmptyArray (Tuple FilePath String)) (List (Module Ann)))
+coreFnModulesFromOutput path globs = runExceptT do
+  paths <- Set.toUnfoldable <$> lift
+    (expandGlobs path ((_ <> "/corefn.json") <$> NonEmptyArray.toArray globs))
+  case NonEmptyArray.toArray globs of
+    [ "**" ] ->
+      sortModules <$> modulesFromPaths paths
+    _ ->
+      go <<< foldl resumePull emptyPull =<< modulesFromPaths paths
+  where
+  modulesFromPaths paths = ExceptT do
+    { left, right } <- separate <$> parTraverse readCoreFnModule paths
+    pure $ maybe (Right right) Left $ NonEmptyArray.fromArray left
+
+  pathFromModuleName (ModuleName mn) =
+    path <> "/" <> mn <> "/corefn.json"
+
+  go pull = case pullResult pull of
+    Left needed ->
+      go <<< foldl resumePull pull =<< modulesFromPaths
+        (pathFromModuleName <$> NonEmptySet.toUnfoldable needed)
+    Right modules ->
+      pure $ Lazy.force modules
+
+readCoreFnModule :: String -> Aff (Either (Tuple FilePath String) (Module Ann))
+readCoreFnModule filePath = do
+  contents <- FS.readTextFile UTF8 filePath
+  case lmap Json.printJsonDecodeError <<< decodeModule =<< Json.jsonParser contents of
+    Left err -> do
+      pure $ Left $ Tuple filePath err
+    Right mod ->
+      pure $ Right mod

--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -9,26 +9,13 @@ module Test.Utils where
 
 import Prelude
 
-import Control.Monad.Except (ExceptT(..), lift, runExceptT)
-import Control.Parallel (parTraverse)
-import Data.Argonaut as Json
 import Data.Array as Array
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Array.NonEmpty.Internal (NonEmptyArray(..))
-import Data.Bifunctor (lmap)
-import Data.Compactable (separate)
 import Data.Either (Either(..))
-import Data.Foldable (foldl)
-import Data.Lazy as Lazy
-import Data.List (List)
-import Data.Maybe (maybe)
 import Data.Posix.Signal (Signal(..))
-import Data.Set as Set
-import Data.Set.NonEmpty as NonEmptySet
-import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff, effectCanceler, error, makeAff, throwError)
 import Effect.Class (liftEffect)
-import Effect.Class.Console as Console
 import Node.Buffer (Buffer, freeze)
 import Node.Buffer.Immutable as ImmutableBuffer
 import Node.ChildProcess (ExecResult, Exit(..), defaultExecOptions, defaultSpawnOptions, inherit)
@@ -39,14 +26,10 @@ import Node.FS.Perms (mkPerms)
 import Node.FS.Perms as Perms
 import Node.FS.Stats as Stats
 import Node.FS.Stream (createReadStream, createWriteStream)
-import Node.Glob.Basic (expandGlobs)
 import Node.Library.Execa (ExecaError, ExecaSuccess, execa)
 import Node.Path (FilePath)
 import Node.Process as Process
 import Node.Stream as Stream
-import PureScript.Backend.Optimizer.CoreFn (Ann, Module, ModuleName(..))
-import PureScript.Backend.Optimizer.CoreFn.Json (decodeModule)
-import PureScript.Backend.Optimizer.CoreFn.Sort (emptyPull, pullResult, resumePull, sortModules)
 import PureScript.CST (RecoveredParserResult(..), parseModule)
 import PureScript.CST.Errors (printParseError)
 import PureScript.CST.Types as CSTT
@@ -118,42 +101,6 @@ copyFile from to = do
       Stream.destroy res
       Stream.destroy dst
       Stream.destroy src
-
-coreFnModulesFromOutput
-  :: String
-  -> NonEmptyArray String
-  -> Aff (Either (NonEmptyArray (Tuple FilePath String)) (List (Module Ann)))
-coreFnModulesFromOutput path globs = runExceptT do
-  paths <- Set.toUnfoldable <$> lift
-    (expandGlobs path ((_ <> "/corefn.json") <$> NonEmptyArray.toArray globs))
-  case NonEmptyArray.toArray globs of
-    [ "**" ] ->
-      sortModules <$> modulesFromPaths paths
-    _ ->
-      go <<< foldl resumePull emptyPull =<< modulesFromPaths paths
-  where
-  modulesFromPaths paths = ExceptT do
-    { left, right } <- separate <$> parTraverse readCoreFnModule paths
-    pure $ maybe (Right right) Left $ NonEmptyArray.fromArray left
-
-  pathFromModuleName (ModuleName mn) =
-    path <> "/" <> mn <> "/corefn.json"
-
-  go pull = case pullResult pull of
-    Left needed ->
-      go <<< foldl resumePull pull =<< modulesFromPaths
-        (pathFromModuleName <$> NonEmptySet.toUnfoldable needed)
-    Right modules ->
-      pure $ Lazy.force modules
-
-readCoreFnModule :: String -> Aff (Either (Tuple FilePath String) (Module Ann))
-readCoreFnModule filePath = do
-  contents <- FS.readTextFile UTF8 filePath
-  case lmap Json.printJsonDecodeError <<< decodeModule =<< Json.jsonParser contents of
-    Left err -> do
-      pure $ Left $ Tuple filePath err
-    Right mod ->
-      pure $ Right mod
 
 -- | Returns `Right true` if the source code has this type signature
 -- | somewhere in it:


### PR DESCRIPTION
Refactor by adding a common builder helper. This removes some duplication we have, mainly the reading of corefn files. Does not change functionality in any way.