### PR TITLE
Fix test suite

### DIFF
--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -169,4 +169,4 @@ recordUpdate h f = do
         ]
   Let false
     (NonEmptyArray.singleton (Tuple "$record" (List [ Identifier $ rtPrefixed "object-copy", h ])))
-    (List $ [ Identifier $ scmPrefixed "begin" ] <> (field <$> f))
+    (List $ [ Identifier $ scmPrefixed "begin" ] <> (field <$> f) <> [ Identifier "$record" ])

--- a/test-snapshots/spago.yaml
+++ b/test-snapshots/spago.yaml
@@ -14,8 +14,8 @@ workspace:
     registry: 19.1.0
   extra_packages:
     prelude:
-      git: https://github.com/anttih/purescript-prelude.git
-      ref: 9f6bf7617b54431e084c593ea98ae379f0cbc5c7
+      git: https://github.com/purescm/purescript-prelude.git
+      ref: b250d70c7bc6528c12e0598c50ad87b7267ccfa9
       dependencies: []
     partial:
       git: https://github.com/purescm/purescript-partial.git

--- a/test-snapshots/spago.yaml
+++ b/test-snapshots/spago.yaml
@@ -14,8 +14,8 @@ workspace:
     registry: 19.1.0
   extra_packages:
     prelude:
-      git: https://github.com/purescm/purescript-prelude.git
-      ref: 63ff5a24beba191c8fda919a58489f36bde2d506
+      git: https://github.com/anttih/purescript-prelude.git
+      ref: 9f6bf7617b54431e084c593ea98ae379f0cbc5c7
       dependencies: []
     partial:
       git: https://github.com/purescm/purescript-partial.git

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -22,7 +22,7 @@
   (scm:define recordUpdate
     (scm:lambda (v0)
       (scm:let ([$record (rt:object-copy v0)])
-        (scm:begin (rt:object-set! $record "fooBarBaz" 10)))))
+        (scm:begin (rt:object-set! $record "fooBarBaz" 10) $record))))
 
   (scm:define recordAddField
     (scm:lambda (_)

--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -78,10 +78,11 @@ loadModuleMain options = do
   spawned <- execa options.scheme arguments identity
   when options.hasMain do
     spawned.stdin.writeUtf8End $ Array.fold
-      [ "(import ("
-      , options.moduleName
-      , " lib)) (with-exception-handler (lambda (e) (display-condition e (console-error-port)) (newline (console-error-port)) (exit -1)) (lambda () (main)))"
+      [ "(base-exception-handler (lambda (e) (display-condition e (console-error-port)) (newline (console-error-port)) (exit -1)))"
+      , "(top-level-program (import (" <> options.moduleName <> " lib)) (main))"
       ]
+  void $ liftEffect $ Stream.pipe spawned.stdout.stream Process.stdout
+  void $ liftEffect $ Stream.pipe spawned.stderr.stream Process.stderr
   spawned.result
 
 copyFile :: FilePath -> FilePath -> Aff Unit


### PR DESCRIPTION
Fixes the test suite by doing a few things:

* The runnable tests were not failing the test suite in case an error was throw during library imports. This happens because the `with-exception-handler` doesn't catch those errors that we generate for missing FFI definitions. Now using the `base-exception-handler` which does catch those, which then fails the build correctly.
* Record update codegen was broken because it did not return the updated-in-place record.
* Use a prelude that implements just enough record and semiring to pass the currect test suite. I will update the package ref once the prelude PR is merged (and before merging this).

Pending [prelude PR](https://github.com/purescm/purescript-prelude/pull/2)