### PR TITLE
Fix copyFile

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -236,6 +236,7 @@ copyFile from to = do
       Stream.destroy' dst $ error $ "Got error in src stream: " <> message err
       k $ Left err
     dst # on_ Stream.errorH (k <<< Left)
+    dst # on_ Stream.finishH (k (Right unit))
     Stream.pipe src dst
     pure $ effectCanceler do
       Stream.destroy dst

--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -85,6 +85,7 @@ copyFile from to = do
       Stream.destroy' dst $ error $ "Got error in src stream: " <> message err
       k $ Left err
     dst # on_ Stream.errorH (k <<< Left)
+    dst # on_ Stream.finishH (k (Right unit))
     Stream.pipe src dst
     pure $ effectCanceler do
       Stream.destroy dst


### PR DESCRIPTION
The build was not completing properly because we never finished the `copyFile`. This was just left out from the node lib upgrade.