### PR TITLE
Upgrade backend-optimizer

### DIFF
--- a/spago.yaml
+++ b/spago.yaml
@@ -73,7 +73,7 @@ workspace:
         - tuples
     backend-optimizer:
       git: https://github.com/aristanetworks/purescript-backend-optimizer
-      ref: 9de6bd8a00d31e51502a062d10bbddf53a401039
+      ref: 54b82ac23143dd47bfafaf52dec81dd7ccf2b490
       dependencies:
         - aff
         - ansi

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -184,6 +184,8 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
   Update e f ->
     S.recordUpdate (codegenExpr codegenEnv e) (map (codegenExpr codegenEnv) <$> f)
 
+  CtorSaturated qi _ _ _ [] ->
+    S.Identifier $ flattenQualified currentModule qi
   CtorSaturated qi _ _ _ [ Tuple _ x ] ->
     S.app
       (S.Identifier $ S.recordTypeCurriedConstructor $ flattenQualified currentModule qi)


### PR DESCRIPTION
`backend-optimizer` [now generates](https://github.com/aristanetworks/purescript-backend-optimizer/pull/98) constructor references with empty arguments instead of generating a `Var`.