### PR TITLE
Make sure to compile to corefn in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "scripts": {
     "test": "spago test",
-    "build": "spago build && purs-backend-es bundle-module -m Main --int-tags --platform=node --minify --to=./bundle/index.js"
+    "build": "spago build --purs-args '-g corefn,js' && purs-backend-es bundle-module -m Main --int-tags --platform=node --minify --to=./bundle/index.js"
   }
 }


### PR DESCRIPTION
`spago` doesn't compile to `corefn` unless told so. We need this for `purs-backend-es` build.