### PR TITLE
Update to Spago 0.93.14, switch to purescript-overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "easy-purescript-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1680076811,
-        "narHash": "sha256-vfzrVwBntXao3nMi2hkjYlWGUnuyUOVmYi95mQQ0EEY=",
-        "owner": "f-f",
-        "repo": "easy-purescript-nix",
-        "rev": "b02cff3db1671fc8fb76a680597a216a9c9b2d03",
-        "type": "github"
-      },
-      "original": {
-        "owner": "f-f",
-        "repo": "easy-purescript-nix",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -33,12 +17,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -63,12 +50,69 @@
         "type": "github"
       }
     },
+    "purescript-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1695548718,
+        "narHash": "sha256-zjfsJfHT/YedX2sAgK9g6X8XTsRH5Cr18hS1iBFvb+w=",
+        "owner": "f-f",
+        "repo": "purescript-overlay",
+        "rev": "278ca324b97e3d9f8c2a744d06a99f4e7d5f2699",
+        "type": "github"
+      },
+      "original": {
+        "owner": "f-f",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "easy-purescript-nix": "easy-purescript-nix",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "purescript-overlay": "purescript-overlay"
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688610262,
+        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -12,33 +12,32 @@
       flake = false;
     };
 
-    easy-purescript-nix = {
-      url = "github:f-f/easy-purescript-nix";
-      flake = false;
-    };
+    purescript-overlay.url = "github:f-f/purescript-overlay";
+    purescript-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, easy-purescript-nix, ... }:
+  outputs = { self, nixpkgs, flake-utils, purescript-overlay, ... }:
     let supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
     in flake-utils.lib.eachSystem supportedSystems (system:
       let
-        pkgs = import nixpkgs { inherit system; };
-        easy-ps = pkgs.callPackage easy-purescript-nix { };
+        overlays = [ purescript-overlay.overlays.default ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
       in
       {
         devShells = {
           default = pkgs.mkShell {
             name = "purescm";
-            packages = [
-              easy-ps.purs-0_15_8
-              easy-ps.purs-tidy
-              easy-ps.psa
-              easy-ps.spago-next
-              easy-ps.purescript-language-server
-              easy-ps.purs-backend-es
-              pkgs.nodejs-slim-16_x
-              pkgs.chez-racket
-              pkgs.esbuild
+            packages = with pkgs; [
+              purescript-language-server
+              purs-backend-es
+              purs-bin.purs-0_15_10
+              purs-tidy
+              spago-unstable
+              nodejs-slim-16_x
+              chez-racket
+              esbuild
             ];
           };
         };

--- a/index.dev.js
+++ b/index.dev.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+import { main } from "./output/Main/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+main(__dirname)();

--- a/test-snapshots/spago.yaml
+++ b/test-snapshots/spago.yaml
@@ -10,6 +10,10 @@ package:
     - record
     - refs
 workspace:
+  backend:
+    cmd: ../index.dev.js
+    args:
+      - build
   package_set:
     registry: 19.1.0
   extra_packages:
@@ -53,7 +57,7 @@ workspace:
     record:
       git: https://github.com/purescm/purescript-record.git
       ref: 8a993da0d328f72167a4742e0e2a428a790510bc
-      dependencies: 
+      dependencies:
         - functions
         - prelude
         - unsafe-coerce

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -82,7 +82,7 @@ runSnapshotTests { accept, filter } = do
   currentDirectory <- liftEffect Process.cwd
   let vendorDirectory = Path.concat [ currentDirectory, "vendor" ]
   liftEffect $ Process.chdir $ Path.concat [ "test-snapshots" ]
-  spawnFromParent "spago" [ "build", "--purs-args", "-g corefn" ]
+  spawnFromParent "spago" [ "build" ]
   snapshotDir <- liftEffect Process.cwd
   snapshotPaths <- expandGlobs (Path.concat [ snapshotDir, "src", "snapshots-input" ])
     [ "Snapshot.*.purs" ]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -14,24 +14,20 @@ import ArgParse.Basic as ArgParser
 import Data.Array (findMap)
 import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray)
+import Data.Array.NonEmpty as NonEmptyArray
 import Data.Either (Either(..), either, isRight)
 import Data.Foldable as Foldable
-import Data.Map as Map
-import Data.Maybe (Maybe(..), fromMaybe, isJust)
+import Data.Maybe (Maybe(..))
 import Data.Monoid (power)
-import Data.Newtype (unwrap)
 import Data.Set as Set
-import Data.String (Pattern(..))
+import Data.String (Pattern(..), Replacement(..))
 import Data.String as String
 import Data.String.CodeUnits as SCU
 import Data.TraversableWithIndex (forWithIndex)
-import Dodo (plainText)
-import Dodo as Dodo
 import Effect (Effect)
 import Effect.Aff (Aff, attempt, launchAff_)
 import Effect.Class (liftEffect)
 import Effect.Class.Console as Console
-import Effect.Ref as Ref
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff as FS
 import Node.Glob.Basic (expandGlobs)
@@ -39,14 +35,10 @@ import Node.Library.Execa.Which (defaultWhichOptions, which)
 import Node.Path as Path
 import Node.Process as Process
 import Partial.Unsafe (unsafeCrashWith)
-import PureScript.Backend.Chez.Builder (basicBuildMain)
-import PureScript.Backend.Chez.Constants (moduleForeign, moduleLib, schemeExt)
-import PureScript.Backend.Chez.Convert (codegenModule)
-import PureScript.Backend.Chez.Printer as P
-import PureScript.Backend.Chez.Runtime (runtimeModule)
+import PureScript.Backend.Chez.Constants (moduleLib, schemeExt)
 import PureScript.Backend.Optimizer.Convert (BackendModule)
-import PureScript.Backend.Optimizer.CoreFn (Comment(..), Module(..), ModuleName(..))
-import Test.Utils (canRunMain, copyFile, execWithStdin, loadModuleMain, mkdirp, spawnFromParent)
+import PureScript.Backend.Optimizer.CoreFn (Comment(..))
+import Test.Utils (canRunMain, execWithStdin, loadModuleMain, mkdirp, spawnFromParent)
 
 type TestArgs =
   { accept :: Boolean
@@ -81,104 +73,84 @@ runSnapshotTests :: TestArgs -> Aff Unit
 runSnapshotTests { accept, filter } = do
   currentDirectory <- liftEffect Process.cwd
   let vendorDirectory = Path.concat [ currentDirectory, "vendor" ]
+
+  -- Get into the snapshot project and build it
   liftEffect $ Process.chdir $ Path.concat [ "test-snapshots" ]
   spawnFromParent "spago" [ "build" ]
   snapshotDir <- liftEffect Process.cwd
-  snapshotPaths <- expandGlobs (Path.concat [ snapshotDir, "src", "snapshots-input" ])
-    [ "Snapshot.*.purs" ]
-  schemeBin <- getSchemeBinary
-  outputRef <- liftEffect $ Ref.new Map.empty
+  let snapshotInput = Path.concat [ snapshotDir, "src", "snapshots-input" ]
   let snapshotsOut = Path.concat [ snapshotDir, "src", "snapshots-output" ]
-  let testOut = Path.concat [ snapshotDir, "test-out" ]
+  snapshotPaths <- expandGlobs snapshotInput (map (_ <> ".purs") $ NonEmptyArray.toArray filter)
   mkdirp snapshotsOut
-  mkdirp testOut
-  -- RUNTIME
-  let runtimePath = Path.concat [ testOut, "purs", "runtime" ]
-  mkdirp runtimePath
-  let runtimeFilePath = Path.concat [ runtimePath, moduleLib <> schemeExt ]
-  let runtimeContents = Dodo.print plainText Dodo.twoSpaces $ P.printLibrary $ runtimeModule
-  FS.writeTextFile UTF8 runtimeFilePath runtimeContents
-  basicBuildMain
-    { coreFnDirectory: "output"
-    , coreFnGlobs: filter
-    , externalDirectivesFile: Nothing
-    , onCodegenModule: \_ (Module { name: ModuleName name, path }) backend _ -> do
-        let
-          formatted =
-            Dodo.print plainText Dodo.twoSpaces
-              $ P.printLibrary
-              $ codegenModule backend
-        let testFileDir = Path.concat [ testOut, name ]
-        let testFilePath = Path.concat [ testFileDir, moduleLib <> schemeExt ]
-        mkdirp testFileDir
-        FS.writeTextFile UTF8 testFilePath formatted
-        unless (Set.isEmpty backend.foreign) do
-          let
-            foreignSiblingPath =
-              fromMaybe path (String.stripSuffix (Pattern (Path.extname path)) path) <>
-                schemeExt
-          let foreignOutputPath = Path.concat [ testFileDir, moduleForeign <> schemeExt ]
-          copyFile foreignSiblingPath foreignOutputPath
-        let snapshotDirFile = Path.concat [ snapshotDir, path ]
-        when (Set.member snapshotDirFile snapshotPaths) do
-          originalFileSourceCode <- FS.readTextFile UTF8 snapshotDirFile
-          hasMain <- either unsafeCrashWith pure $
-            canRunMain originalFileSourceCode
-          void $ liftEffect $ Ref.modify
-            (Map.insert name ({ formatted, failsWith: hasFails backend, hasMain }))
-            outputRef
-    , onPrepareModule: \build coreFnMod@(Module { name }) -> do
-        let total = show build.moduleCount
-        let index = show (build.moduleIndex + 1)
-        let padding = power " " (SCU.length total - SCU.length index)
-        Console.log $ "[" <> padding <> index <> " of " <> total <> "] Building " <> unwrap name
-        pure coreFnMod
-    }
-  outputModules <- liftEffect $ Ref.read outputRef
-  results <- forWithIndex outputModules \name ({ formatted, failsWith, hasMain }) -> do
+  schemeBin <- getSchemeBinary
+
+  -- Tests return true or false depending on whether they pass
+  results <- forWithIndex (Set.toUnfoldable snapshotPaths :: Array _) \i snapshotInputPath -> do
     let
-      snapshotFilePath = Path.concat [ snapshotsOut, name <> schemeExt ]
+      -- The idea here is that we get files from the `output` directory, and check if
+      -- they look like the ones we have in `snapshots-output`
+      expectedSnapshotOutputPath =
+        String.replace (Pattern snapshotInput) (Replacement snapshotsOut)
+          $ String.replace (Pattern ".purs") (Replacement schemeExt)
+          $ snapshotInputPath
+      actualSnapshotOutputPath =
+        String.replace (Pattern snapshotInput) (Replacement (Path.concat [ snapshotDir, "output" ]))
+          $ String.replace (Pattern ".purs") (Replacement $ "/" <> moduleLib <> schemeExt)
+          $ snapshotInputPath
+      name = String.replace (Pattern $ snapshotInput <> "/") (Replacement "")
+        $ String.replace (Pattern ".purs") (Replacement "")
+        $ snapshotInputPath
+
+    let
+      total = show $ Set.size snapshotPaths
+      index = show i
+      padding = power " " (SCU.length total - SCU.length index)
+    Console.log $ "[" <> padding <> index <> " of " <> total <> "] Running test " <> name
+
+    -- Read the file generated by purescm
+    actualSnapshotOutput <- FS.readTextFile UTF8 actualSnapshotOutputPath
+    purescriptFile <- FS.readTextFile UTF8 snapshotInputPath
+    hasMain <- either unsafeCrashWith pure $ canRunMain purescriptFile
+
+    let
       runAcceptedTest = do
-        schemeFile <- liftEffect $ Path.resolve [ testOut, name ] $ moduleLib <> schemeExt
         result <- loadModuleMain
-          { libdir: vendorDirectory <> ":" <> testOut
+          { libdir: vendorDirectory <> ":" <> "output"
           , scheme: schemeBin
           , hasMain
-          , modulePath: schemeFile
+          , modulePath: actualSnapshotOutputPath
           , moduleName: name
           }
         case result.exitCode of
-          Just 0
-            | isJust failsWith -> do
-                Console.log $ withGraphics (foreground Red) "✗" <> " " <> name <>
-                  " succeeded when it should have failed."
-                pure false
-            | otherwise ->
-                pure true
-          _
-            | matchesFail result.message failsWith ->
-                pure true
-            | otherwise -> do
-                Console.log $ withGraphics (foreground Red) "✗" <> " " <> name <> " failed."
-                Console.log result.message
-                pure false
-    attempt (FS.readTextFile UTF8 snapshotFilePath) >>= case _ of
+          Just 0 -> pure true
+          _ -> do
+            Console.log $ withGraphics (foreground Red) "✗" <> " " <> name <> " failed."
+            Console.log result.message
+            pure false
+
+    attempt (FS.readTextFile UTF8 expectedSnapshotOutputPath) >>= case _ of
+      -- If we don't have this fixture yet, save it
       Left _ -> do
         Console.log $ withGraphics (foreground Yellow) "✓" <> " " <> name <> " saved."
-        FS.writeTextFile UTF8 snapshotFilePath formatted
+        FS.writeTextFile UTF8 expectedSnapshotOutputPath actualSnapshotOutput
         pure true
       Right prevOutput
-        | formatted == prevOutput ->
+        -- We have and it looks the same  -> run it
+        | actualSnapshotOutput == prevOutput ->
             runAcceptedTest
+        -- We have it but we are accepting the new output -> save it, and run it afterwards
         | accept -> do
             Console.log $ withGraphics (foreground Yellow) "✓" <> " " <> name <> " accepted."
-            FS.writeTextFile UTF8 snapshotFilePath formatted
+            FS.writeTextFile UTF8 expectedSnapshotOutputPath actualSnapshotOutput
             runAcceptedTest
+        -- We have it and it's broken
         | otherwise -> do
             Console.log $ withGraphics (foreground Red) "✗" <> " " <> name <> " failed."
-            diff <- _.stdout <$> execWithStdin "diff" [ snapshotFilePath, "-" ] formatted
+            diff <- _.stdout <$> execWithStdin "diff" [ expectedSnapshotOutputPath, "-" ]
+              actualSnapshotOutput
             Console.log diff
             pure false
+
   unless (Foldable.and results) do
     liftEffect $ Process.exit' 1
 


### PR DESCRIPTION
This updates to the latest Spago, which will compile to corefn all the time, and to js only when the backend is not provided.

We also switch from easy-purescript-nix to purescript-overlay for the nix machinery, as it's generally more up to date.

Closes #161 