### PR TITLE
Add run cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,21 @@ Then to compile your `purescm` project you can run:
 spago build
 ```
 
-This will produce output under `output/`. You can then further precompile the scheme files to a single Chez program:
+This will produce output under `output/`. You can run the compiled program with:
 
 ```
-purescm bundle-app --main Main
+purescm run
 ```
 
-which generates a single file `output/main`. To run the compiled program:
+### Bundling
+
+Scheme files can be precompiled to a single Chez program:
+
+```
+purescm bundle-app
+```
+
+which generates a single file `output/main` which can be run with `scheme` or `petite`:
 
 ```
 scheme --program output/main

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -75,7 +75,8 @@ cliArgParser =
         "Bundles .so files to a single program file."
         do Bundle <$> bundleCmdArgParser <* ArgParser.flagHelp
     , ArgParser.command [ "run" ]
-        "Runs a compiled scheme program by invoking the main function using the Chez interpreter."
+        "Runs a compiled scheme program by invoking\n\
+        \the main function using the Chez interpreter."
         do Run <$> runCmdArgParser <* ArgParser.flagHelp
     ]
     <* ArgParser.flagHelp

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -70,20 +70,20 @@ cliArgParser =
     [ ArgParser.command [ "build" ]
         "Builds Chez scheme code from corefn.json files"
         do
-          Build <$> buildArgsParser <* ArgParser.flagHelp
+          Build <$> buildCmdArgParser <* ArgParser.flagHelp
     , ArgParser.command [ "bundle-app" ]
         "Bundles .so files to a single program file."
-        do Bundle <$> bundleArgsParser <* ArgParser.flagHelp
+        do Bundle <$> bundleCmdArgParser <* ArgParser.flagHelp
     , ArgParser.command [ "run" ]
         "Runs a compiled scheme program by invoking the main function using the Chez interpreter."
-        do Run <$> runArgsParser <* ArgParser.flagHelp
+        do Run <$> runCmdArgParser <* ArgParser.flagHelp
     ]
     <* ArgParser.flagHelp
     <* ArgParser.flagInfo [ "--version", "-v" ] "Show the current version of purescm."
       BuildInfo.buildInfo.packages.purescm
 
-buildArgsParser :: ArgParser BuildArgs
-buildArgsParser =
+buildCmdArgParser :: ArgParser BuildArgs
+buildCmdArgParser =
   ArgParser.fromRecord
     { coreFnDir:
         ArgParser.argument [ "--corefn-dir" ]
@@ -101,8 +101,8 @@ buildArgsParser =
           # ArgParser.optional
     }
 
-bundleArgsParser :: ArgParser BundleArgs
-bundleArgsParser =
+bundleCmdArgParser :: ArgParser BundleArgs
+bundleCmdArgParser =
   ArgParser.fromRecord
     { moduleName:
         ArgParser.argument [ "--main" ]
@@ -121,8 +121,8 @@ bundleArgsParser =
           # ArgParser.default (Path.concat [ ".", "output" ])
     }
 
-runArgsParser :: ArgParser RunArgs
-runArgsParser =
+runCmdArgParser :: ArgParser RunArgs
+runCmdArgParser =
   ArgParser.fromRecord
     { moduleName:
         ArgParser.argument [ "--main" ]


### PR DESCRIPTION
Adds a `run` command that allows you to skip the bundling and just eval `main`.

Adding this mainly to make running test suites in libraries easier. I was considering also adding a `test` command that would compile and run, but since spago can't be used to call `purescm run` and because I'd like to still use `spago` as much as possible the easiest path for now seems to just add a `run` and then in libraries do `spago build && purescm run --main Test.Main`.