### PR TITLE
Fix bug with PrimEffect

### DIFF
--- a/test-snapshots/src/snapshots-input/Snapshot.EffectRef.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.EffectRef.purs
@@ -31,7 +31,14 @@ onLetTest = do
   v <- read n
   assert $ v == 5
 
+primEffectAtTheEnd :: Effect Int
+primEffectAtTheEnd = do
+  n <- new 1
+  read n
+
 main :: Effect Unit
 main = do
   basicTest
   onLetTest
+  _ <- primEffectAtTheEnd
+  pure unit

--- a/test-snapshots/src/snapshots-output/Snapshot.EffectRef.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.EffectRef.ss
@@ -7,11 +7,18 @@
     main
     onLet
     onLetTest
-    positionZero)
+    positionZero
+    primEffectAtTheEnd)
   (import
     (prefix (chezscheme) scm:)
     (prefix (purs runtime lib) rt:)
+    (prefix (Data.Unit lib) Data.Unit.)
     (prefix (Test.Assert lib) Test.Assert.))
+
+  (scm:define primEffectAtTheEnd
+    (scm:lambda ()
+      (scm:let ([n0 (scm:box 1)])
+        (scm:unbox n0))))
 
   (scm:define positionZero
     (scm:lambda ()
@@ -44,5 +51,8 @@
 
   (scm:define main
     (scm:lambda ()
-      (scm:let ([_ (basicTest)])
-        (onLetTest)))))
+      (scm:let*
+        ([_ (basicTest)]
+         [_ (onLetTest)]
+         [_ (primEffectAtTheEnd)])
+          Data.Unit.unit))))


### PR DESCRIPTION
Fix bug where all previous bindings in a do block were dropped if the last `bind` was a `PrimEffect`.