### PR TITLE
Fix primitive assignment effect

### DIFF
--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -492,4 +492,11 @@ codegenPrimEffect codegenEnv = case _ of
     S.app (S.Identifier $ scmPrefixed "unbox") (codegenExpr codegenEnv r)
   EffectRefWrite r v ->
     S.List
-      [ S.Identifier $ scmPrefixed "set-box!", codegenExpr codegenEnv r, codegenExpr codegenEnv v ]
+      [ S.Identifier $ scmPrefixed "begin"
+      , S.List
+          [ S.Identifier $ scmPrefixed "set-box!"
+          , codegenExpr codegenEnv r
+          , codegenExpr codegenEnv v
+          ]
+      , S.List [ S.Identifier $ scmPrefixed "unbox", codegenExpr codegenEnv r ]
+      ]

--- a/test-snapshots/src/snapshots-input/Snapshot.EffectRef.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.EffectRef.purs
@@ -4,7 +4,8 @@ module Snapshot.EffectRef where
 import Prelude
 
 import Effect (Effect)
-import Effect.Ref (Ref, modify_, new, read)
+import Effect.Ref (Ref, modify, modify_, new, read)
+import Effect.Class.Console (log)
 import Test.Assert (assert)
 
 positionZero :: Effect (Ref Int)
@@ -36,9 +37,17 @@ primEffectAtTheEnd = do
   n <- new 1
   read n
 
+newCase :: Effect Unit
+newCase = do
+  counter <- new 0
+  newCounter <- modify (_ + 1) counter
+  log $ "New counter is " <> show newCounter
+  assert $ newCounter == 1
+
 main :: Effect Unit
 main = do
   basicTest
   onLetTest
+  newCase
   _ <- primEffectAtTheEnd
   pure unit

--- a/test-snapshots/src/snapshots-output/Snapshot.EffectRef.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.EffectRef.ss
@@ -5,6 +5,7 @@
   (export
     basicTest
     main
+    newCase
     onLet
     onLetTest
     positionZero
@@ -12,7 +13,9 @@
   (import
     (prefix (chezscheme) scm:)
     (prefix (purs runtime lib) rt:)
+    (prefix (Data.Show lib) Data.Show.)
     (prefix (Data.Unit lib) Data.Unit.)
+    (prefix (Effect.Console lib) Effect.Console.)
     (prefix (Test.Assert lib) Test.Assert.))
 
   (scm:define primEffectAtTheEnd
@@ -40,12 +43,21 @@
            [v2 (scm:unbox n1)])
             ((Test.Assert.assert (scm:fx=? v2 5)))))))
 
+  (scm:define newCase
+    (scm:lambda ()
+      (scm:let*
+        ([counter0 (scm:box 0)]
+         [_1 (scm:unbox counter0)]
+         [newCounter2 (scm:begin (scm:set-box! counter0 (scm:fx+ _1 1)) (scm:unbox counter0))]
+         [_ ((Effect.Console.log (scm:string-append "New counter is " (Data.Show.showIntImpl newCounter2))))])
+          ((Test.Assert.assert (scm:fx=? newCounter2 1))))))
+
   (scm:define basicTest
     (scm:lambda ()
       (scm:let*
         ([n0 (scm:box 0)]
          [_1 (scm:unbox n0)]
-         [a$p2 (scm:set-box! n0 (scm:fx+ _1 1))]
+         [a$p2 (scm:begin (scm:set-box! n0 (scm:fx+ _1 1)) (scm:unbox n0))]
          [v3 (scm:unbox n0)])
           ((Test.Assert.assert (scm:fx=? v3 1))))))
 
@@ -54,5 +66,6 @@
       (scm:let*
         ([_ (basicTest)]
          [_ (onLetTest)]
+         [_ (newCase)]
          [_ (primEffectAtTheEnd)])
           Data.Unit.unit))))


### PR DESCRIPTION
We need to return the value in addition to just setting the value of the box. This is not a super nice fix. I think we should refactor the prim effect stuff so that we get more control over what bindings we create, then we can also compile these to plain unboxed assigment.

Fixes #204 