### PR TITLE
Remove flake-utils

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@PureFunctor](https://github.com/PureFunctor), [@sjpgarcia](https://github.com/sjpgarcia) | Justin Garcia | [Apache-2.0] |
 | [@turlando](https://github.com/turlando) | Tancredi Orlando | [Apache-2.0] |
 | [@anttih](https://github.com/anttih) | Antti Holvikari | [Apache-2.0] |
+| toastal | toastal | [Apache-2.0] |
 
 ### Contributors using Modified Terms
 

--- a/flake.lock
+++ b/flake.lock
@@ -16,24 +16,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1680030621,
@@ -74,7 +56,6 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "purescript-overlay": "purescript-overlay"
       }
@@ -97,21 +78,6 @@
       "original": {
         "owner": "thomashoneyman",
         "repo": "slimlock",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }


### PR DESCRIPTION
> 24 additions & 51 deletions

There is no need to include a dependency for what is effectively a for loop. Including this dependency will have an effect on all downstream users as they will now have their `flake.lock` infected with this dependency. Considering this is also a smaller diff, there is no value in having flake-utils.

Blue Oak license is simpler & framed less in terms of US law than Apache. If this isn’t okay, then I will force push a `BSD-2-Clause-Patent`--& if that isn’t okay, then I’ll go with `Apache-2.0` like the rest (all of these are permissive with patent clauses… I don’t care _that_ much TBH, but I think Blue Oak is overlooked/underrated).

Contribution link omitted as eventually toastal would like to delete his Microsoft GitHub account once more projects offer contribution options which do not force proprietary platform lock-in.