### PR TITLE
Use assoc lists for records

### DIFF
--- a/package-sets/1.0.0.json
+++ b/package-sets/1.0.0.json
@@ -5,56 +5,56 @@
   "packages": {
     "arrays": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "arrays"
     },
     "assert": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "assert"
     },
     "bifunctors": "6.0.0",
     "catenable-lists": "7.0.0",
     "console": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "console"
     },
     "const": "6.0.0",
     "contravariant": "6.0.0",
     "control": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "control"
     },
     "distributive": "6.0.0",
     "effect": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "effect"
     },
     "either": "6.1.0",
     "enums": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "enums"
     },
     "exceptions": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "exceptions"
     },
     "exists": "6.0.0",
     "filterable": "5.0.0",
     "foldable-traversable": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "foldable-traversable"
     },
     "free": "7.1.0",
     "functions": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "functions",
       "dependencies": [
         "prelude"
@@ -65,27 +65,27 @@
     "identity": "6.0.0",
     "integers": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "integers"
     },
     "invariant": "6.0.0",
     "lazy": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "lazy"
     },
     "lists": "7.0.0",
     "maybe": "6.0.0",
     "minibench": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "minibench"
     },
     "newtype": "5.0.0",
     "nonempty": "7.0.0",
     "numbers": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "numbers"
     },
     "ordered-collections": "3.1.1",
@@ -93,24 +93,24 @@
     "parallel": "7.0.0",
     "partial": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "partial",
       "dependencies": []
     },
     "prelude": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "prelude"
     },
     "profunctor": "6.0.0",
     "record": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "record"
     },
     "refs": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "refs",
       "dependencies": [
         "effect",
@@ -120,7 +120,7 @@
     "safe-coerce": "2.0.0",
     "st": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "st"
     },
     "semirings": "7.0.0",
@@ -130,12 +130,12 @@
     "type-equality": "4.0.1",
     "unfoldable": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "unfoldable"
     },
     "unsafe-coerce": {
       "git": "https://github.com/purescm/purescript-core.git",
-      "ref": "67a140e5e7dd4129c4fc81b08a401fc56e263aa8",
+      "ref": "154d77119aa25b70f07f4b880dcba41ed811a852",
       "subdir": "unsafe-coerce",
       "dependencies": []
     },

--- a/spago.lock
+++ b/spago.lock
@@ -1,0 +1,1752 @@
+workspace:
+  packages:
+    purescm:
+      path: ./
+      dependencies:
+        - aff
+        - argonaut
+        - arrays
+        - backend-optimizer
+        - console
+        - control
+        - dodo-printer
+        - effect
+        - foldable-traversable
+        - maybe
+        - newtype
+        - ordered-collections
+        - prelude
+        - safe-coerce
+        - strings
+        - transformers
+        - tuples
+      test_dependencies:
+        - ansi
+        - argparse-basic
+        - bifunctors
+        - either
+        - filterable
+        - language-cst-parser
+        - lazy
+        - lists
+        - node-buffer
+        - node-child-process
+        - node-execa
+        - node-fs
+        - node-glob-basic
+        - node-path
+        - node-process
+        - node-streams
+        - parallel
+        - partial
+        - posix-types
+        - refs
+      build_plan:
+        - aff
+        - ansi
+        - argonaut
+        - argonaut-codecs
+        - argonaut-core
+        - argonaut-traversals
+        - argparse-basic
+        - arraybuffer-types
+        - arrays
+        - avar
+        - backend-optimizer
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - datetime
+        - debug
+        - distributive
+        - dodo-printer
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - filterable
+        - foldable-traversable
+        - foreign
+        - foreign-object
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-date
+        - js-timers
+        - language-cst-parser
+        - lazy
+        - lists
+        - maybe
+        - minibench
+        - newtype
+        - node-buffer
+        - node-child-process
+        - node-event-emitter
+        - node-execa
+        - node-fs
+        - node-glob-basic
+        - node-human-signals
+        - node-os
+        - node-path
+        - node-process
+        - node-streams
+        - nonempty
+        - now
+        - nullable
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - parsing
+        - partial
+        - posix-types
+        - prelude
+        - profunctor
+        - profunctor-lenses
+        - record
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - transformers
+        - tuples
+        - type-equality
+        - typelevel-prelude
+        - unfoldable
+        - unicode
+        - unsafe-coerce
+        - unsafe-reference
+  package_set:
+    address:
+      registry: 41.2.0
+    compiler: ">=0.15.10 <0.16.0"
+    content:
+      abc-parser: 2.0.1
+      ace: 9.1.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      array-search: 0.5.6
+      arraybuffer: 13.2.0
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.2.1
+      arrays-extra: 0.3.0
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      assert-multiple: 0.3.4
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.9
+      bookhound: 0.1.3
+      bower-json: 3.0.0
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      chameleon: 1.0.0
+      chameleon-halogen: 1.0.3
+      chameleon-react-basic: 1.1.0
+      chameleon-styled: 2.5.0
+      chameleon-transformers: 1.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.0.0
+      codec-argonaut: 10.0.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.0.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      css: 6.0.0
+      css-frameworks: 1.0.1
+      data-mvc: 0.0.2
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.23
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dom-filereader: 7.0.0
+      dom-indexed: 12.0.0
+      dotenv: 4.0.3
+      droplet: 0.6.0
+      dts: 0.2.0
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.10.0
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.9.1
+      elmish-html: 0.8.1
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      env-names: 0.3.4
+      error: 2.0.0
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.1.0
+      fetch: 3.0.0
+      fetch-argonaut: 1.0.1
+      fetch-core: 5.1.0
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fix-functor: 0.1.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.3.0
+      float32: 2.0.0
+      fmt: 0.2.0
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      forgetmenot: 0.1.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.1.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geojson: 0.0.5
+      geometry-plane: 1.0.3
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.2.0
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.3
+      halogen-helix: 1.0.0
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 8.0.0
+      halogen-typewriter: 1.0.2
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.8
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-db: 1.0.0
+      indexed-monad: 3.0.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.10.0
+      jelly-router: 0.3.0
+      jelly-signal: 0.4.0
+      jest: 1.0.0
+      js-abort-controller: 1.0.0
+      js-bigints: 2.1.0
+      js-date: 8.0.0
+      js-fileio: 3.0.0
+      js-intl: 1.0.2
+      js-iterators: 0.1.1
+      js-maps: 0.1.2
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      json-codecs: 4.0.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      labeled-data: 0.2.0
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      liminal: 1.0.1
+      linalg: 6.0.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      machines: 7.0.0
+      maps-eager: 0.4.1
+      marionette: 1.0.0
+      marionette-react-basic-hooks: 0.1.1
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      media-types: 6.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mvc: 0.0.1
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      nanoid: 0.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextjs: 0.1.1
+      nextui: 0.2.0
+      node-buffer: 9.0.0
+      node-child-process: 11.0.0
+      node-event-emitter: 3.0.0
+      node-execa: 4.0.1
+      node-fs: 9.1.0
+      node-http: 9.1.0
+      node-http2: 1.1.1
+      node-human-signals: 1.0.0
+      node-net: 5.1.0
+      node-os: 5.1.0
+      node-path: 5.0.0
+      node-process: 11.2.0
+      node-readline: 8.1.0
+      node-sqlite3: 8.0.0
+      node-streams: 9.0.0
+      node-tls: 0.3.1
+      node-url: 7.0.0
+      node-zlib: 0.4.0
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numberfield: 0.1.0
+      numbers: 9.0.1
+      oak: 3.1.1
+      oak-debug: 1.2.2
+      object-maps: 0.3.0
+      ocarina: 1.5.4
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      ordered-collections: 3.1.1
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      pairs: 9.0.1
+      parallel: 7.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.11.0
+      phaser: 0.7.0
+      phylio: 1.1.2
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      pmock: 0.6.0
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.3.0
+      psa-utils: 8.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.2.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 6.0.0
+      rdf: 0.1.0
+      react: 11.0.0
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.1.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.2.0
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.1.1
+      react-markdown: 0.1.0
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      recharts: 1.1.0
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.4
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.3.0
+      sparse-polynomials: 2.0.5
+      spec: 7.5.5
+      spec-mocha: 5.0.0
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      statistics: 0.3.2
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.2.1
+      tecton-halogen: 0.2.0
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      transformation-matrix: 1.0.1
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typedenv: 2.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unique: 0.6.1
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      variant-encodings: 2.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-cssom-view: 0.1.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 4.0.1
+      web-file: 4.0.0
+      web-geometry: 0.1.0
+      web-html: 4.1.0
+      web-pointerevents: 1.0.0
+      web-proletarian: 1.0.0
+      web-resize-observer: 2.0.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 4.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 4.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.1
+      webextension-polyfill: 0.1.0
+      webgpu: 0.0.1
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 5.1.0
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
+      z3: 0.0.2
+  extra_packages:
+    backend-optimizer:
+      git: https://github.com/aristanetworks/purescript-backend-optimizer
+      ref: 54b82ac23143dd47bfafaf52dec81dd7ccf2b490
+      dependencies:
+        - aff
+        - ansi
+        - argonaut
+        - argparse-basic
+        - arrays
+        - bifunctors
+        - console
+        - control
+        - datetime
+        - debug
+        - dodo-printer
+        - effect
+        - either
+        - enums
+        - filterable
+        - foldable-traversable
+        - foreign-object
+        - integers
+        - language-cst-parser
+        - lazy
+        - lists
+        - maybe
+        - newtype
+        - now
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - posix-types
+        - prelude
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - transformers
+        - tuples
+        - unsafe-coerce
+    dodo-printer:
+      git: https://github.com/natefaubion/purescript-dodo-printer.git
+      ref: 831c5c963a57ca4bfd62f96335267d7d0785851d
+      dependencies:
+        - aff
+        - ansi
+        - arrays
+        - avar
+        - console
+        - control
+        - effect
+        - either
+        - exceptions
+        - foldable-traversable
+        - integers
+        - lists
+        - maybe
+        - minibench
+        - newtype
+        - parallel
+        - partial
+        - posix-types
+        - prelude
+        - safe-coerce
+        - strings
+        - tuples
+    language-cst-parser:
+      git: https://github.com/natefaubion/purescript-language-cst-parser.git
+      ref: bf5623e08e1f43f923d4ff3c29cafbda25128768
+      dependencies:
+        - arrays
+        - console
+        - const
+        - control
+        - effect
+        - either
+        - enums
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - identity
+        - integers
+        - lazy
+        - lists
+        - maybe
+        - newtype
+        - node-process
+        - numbers
+        - ordered-collections
+        - partial
+        - prelude
+        - st
+        - strings
+        - transformers
+        - tuples
+        - typelevel-prelude
+        - unfoldable
+        - unsafe-coerce
+    node-glob-basic:
+      git: https://github.com/natefaubion/purescript-node-glob-basic.git
+      ref: v1.2.2
+      dependencies:
+        - aff
+        - console
+        - effect
+        - lists
+        - maybe
+        - node-fs
+        - node-path
+        - node-process
+        - ordered-collections
+        - strings
+packages:
+  aff:
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
+    dependencies:
+      - arrays
+      - bifunctors
+      - control
+      - datetime
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - functions
+      - maybe
+      - newtype
+      - parallel
+      - prelude
+      - refs
+      - tailrec
+      - transformers
+      - unsafe-coerce
+  ansi:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-ZMB6HD+q9CXvn9fRCmJ8dvuDrOVHcjombL3oNOerVnE=
+    dependencies:
+      - foldable-traversable
+      - lists
+      - strings
+  argonaut:
+    type: registry
+    version: 9.0.0
+    integrity: sha256-9sHzkzcFkaMUa9+3FjIybJDYnHtY4Jp4zHOJ84qPTXo=
+    dependencies:
+      - argonaut-codecs
+      - argonaut-core
+      - argonaut-traversals
+  argonaut-codecs:
+    type: registry
+    version: 9.1.0
+    integrity: sha256-N6efXByUeg848ompEqJfVvZuZPfdRYDGlTDFn0G0Oh8=
+    dependencies:
+      - argonaut-core
+      - arrays
+      - effect
+      - foreign-object
+      - identity
+      - integers
+      - maybe
+      - nonempty
+      - ordered-collections
+      - prelude
+      - record
+  argonaut-core:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-RC82GfAjItydxrO24cdX373KHVZiLqybu19b5X8u7B4=
+    dependencies:
+      - arrays
+      - control
+      - either
+      - foreign-object
+      - functions
+      - gen
+      - maybe
+      - nonempty
+      - prelude
+      - strings
+      - tailrec
+  argonaut-traversals:
+    type: registry
+    version: 10.0.0
+    integrity: sha256-9nSfqR70rjiNWVVsCoK+jrm9dmyZTx89IKNYO6uNUIk=
+    dependencies:
+      - argonaut-codecs
+      - argonaut-core
+      - profunctor-lenses
+  argparse-basic:
+    type: registry
+    version: 2.0.0
+    integrity: sha256-3Pp8MDfRL2oeBdfxXIUVJBdhGniaahw2UOG4QmHPm58=
+    dependencies:
+      - arrays
+      - bifunctors
+      - control
+      - either
+      - foldable-traversable
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - prelude
+      - record
+      - strings
+      - tuples
+      - unfoldable
+  arraybuffer-types:
+    type: registry
+    version: 3.0.2
+    integrity: sha256-mQKokysYVkooS4uXbO+yovmV/s8b138Ws3zQvOwIHRA=
+    dependencies: []
+  arrays:
+    type: registry
+    version: 7.2.1
+    integrity: sha256-HCUzV3uCSt6YBI9vlt1Ott20/2JfSCUoNsd+D6ORieQ=
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - functions
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - safe-coerce
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  avar:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-e7hf0x4hEpcygXP0LtvfvAQ49Bbj2aWtZT3gqM///0A=
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - functions
+      - maybe
+  backend-optimizer:
+    type: git
+    url: https://github.com/aristanetworks/purescript-backend-optimizer
+    rev: 54b82ac23143dd47bfafaf52dec81dd7ccf2b490
+    dependencies:
+      - aff
+      - ansi
+      - argonaut
+      - argparse-basic
+      - arrays
+      - bifunctors
+      - console
+      - control
+      - datetime
+      - debug
+      - dodo-printer
+      - effect
+      - either
+      - enums
+      - filterable
+      - foldable-traversable
+      - foreign-object
+      - integers
+      - language-cst-parser
+      - lazy
+      - lists
+      - maybe
+      - newtype
+      - now
+      - numbers
+      - ordered-collections
+      - orders
+      - parallel
+      - partial
+      - posix-types
+      - prelude
+      - refs
+      - safe-coerce
+      - st
+      - strings
+      - transformers
+      - tuples
+      - unsafe-coerce
+  bifunctors:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-gJpJ53fCDAL8BiCiJXH0HNAJ9K3gJtLo8GDaCK6hA5U=
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  debug:
+    type: registry
+    version: 6.0.2
+    integrity: sha256-vmkYFuXYuELBzeauvgHG6E6Kf/Hp1dAnxwE9ByHfwSg=
+    dependencies:
+      - functions
+      - prelude
+  distributive:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  dodo-printer:
+    type: git
+    url: https://github.com/natefaubion/purescript-dodo-printer.git
+    rev: 831c5c963a57ca4bfd62f96335267d7d0785851d
+    dependencies:
+      - aff
+      - ansi
+      - arrays
+      - avar
+      - console
+      - control
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - integers
+      - lists
+      - maybe
+      - minibench
+      - newtype
+      - parallel
+      - partial
+      - posix-types
+      - prelude
+      - safe-coerce
+      - strings
+      - tuples
+  effect:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
+    dependencies:
+      - prelude
+  either:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
+    dependencies:
+      - unsafe-coerce
+  filterable:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-cCojJHRnTmpY1j1kegI4CFwghdQ2Fm/8dzM8IlC+lng=
+    dependencies:
+      - arrays
+      - either
+      - foldable-traversable
+      - identity
+      - lists
+      - ordered-collections
+  foldable-traversable:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  foreign:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=
+    dependencies:
+      - either
+      - functions
+      - identity
+      - integers
+      - lists
+      - maybe
+      - prelude
+      - strings
+      - transformers
+  foreign-object:
+    type: registry
+    version: 4.1.0
+    integrity: sha256-q24okj6mT+yGHYQ+ei/pYPj5ih6sTbu7eDv/WU56JVo=
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - functions
+      - gen
+      - lists
+      - maybe
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - typelevel-prelude
+      - unfoldable
+  free:
+    type: registry
+    version: 7.1.0
+    integrity: sha256-JAumgEsGSzJCNLD8AaFvuX7CpqS5yruCngi6yI7+V5k=
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
+    dependencies:
+      - prelude
+  functors:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
+    dependencies:
+      - control
+      - prelude
+  js-date:
+    type: registry
+    version: 8.0.0
+    integrity: sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - foreign
+      - integers
+      - now
+  js-timers:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-znHWLSSOYw15P5DTcsAdal2lf7nGA2yayLdOZ2t5r7o=
+    dependencies:
+      - effect
+  language-cst-parser:
+    type: git
+    url: https://github.com/natefaubion/purescript-language-cst-parser.git
+    rev: bf5623e08e1f43f923d4ff3c29cafbda25128768
+    dependencies:
+      - arrays
+      - console
+      - const
+      - control
+      - effect
+      - either
+      - enums
+      - foldable-traversable
+      - free
+      - functions
+      - functors
+      - identity
+      - integers
+      - lazy
+      - lists
+      - maybe
+      - newtype
+      - node-process
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - st
+      - strings
+      - transformers
+      - tuples
+      - typelevel-prelude
+      - unfoldable
+      - unsafe-coerce
+  lazy:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lists:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  minibench:
+    type: registry
+    version: 4.0.1
+    integrity: sha256-7jyxcklZI49q/otYvMV4f9YnJwEqQ3Me5buhDwAOydw=
+    dependencies:
+      - console
+      - effect
+      - integers
+      - numbers
+      - partial
+      - prelude
+      - refs
+  newtype:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
+    dependencies:
+      - prelude
+      - safe-coerce
+  node-buffer:
+    type: registry
+    version: 9.0.0
+    integrity: sha256-PWE2DJ5ruBLCmeA/fUiuySEFmUJ/VuRfyrnCuVZBlu4=
+    dependencies:
+      - arraybuffer-types
+      - effect
+      - maybe
+      - nullable
+      - st
+      - unsafe-coerce
+  node-child-process:
+    type: registry
+    version: 11.0.0
+    integrity: sha256-1183hFdWspCBzmjIB7m79PpF9g0NB189X5V6WzeiQxo=
+    dependencies:
+      - exceptions
+      - foreign
+      - foreign-object
+      - functions
+      - node-event-emitter
+      - node-fs
+      - node-os
+      - node-streams
+      - nullable
+      - posix-types
+      - unsafe-coerce
+  node-event-emitter:
+    type: registry
+    version: 3.0.0
+    integrity: sha256-Qw0MjsT4xRH2j2i4K8JmRjcMKnH5z1Cw39t00q4LE4w=
+    dependencies:
+      - effect
+      - either
+      - functions
+      - maybe
+      - nullable
+      - prelude
+      - unsafe-coerce
+  node-execa:
+    type: registry
+    version: 4.0.1
+    integrity: sha256-f1we41uNEZD7Z2kP/GP2/8tOmtsrAnQWIDwFUiqJDwk=
+    dependencies:
+      - aff
+      - arrays
+      - control
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - foreign-object
+      - functions
+      - integers
+      - js-timers
+      - maybe
+      - node-buffer
+      - node-child-process
+      - node-event-emitter
+      - node-fs
+      - node-human-signals
+      - node-os
+      - node-path
+      - node-process
+      - node-streams
+      - nullable
+      - numbers
+      - ordered-collections
+      - parallel
+      - parsing
+      - partial
+      - posix-types
+      - prelude
+      - record
+      - refs
+      - safe-coerce
+      - strings
+      - tailrec
+      - tuples
+      - unsafe-coerce
+      - unsafe-reference
+  node-fs:
+    type: registry
+    version: 9.1.0
+    integrity: sha256-TzhvGdrwcM0bazDvrWSqh+M/H8GKYf1Na6aGm2Qg4+c=
+    dependencies:
+      - datetime
+      - effect
+      - either
+      - enums
+      - exceptions
+      - functions
+      - integers
+      - js-date
+      - maybe
+      - node-buffer
+      - node-path
+      - node-streams
+      - nullable
+      - partial
+      - prelude
+      - strings
+      - unsafe-coerce
+  node-glob-basic:
+    type: git
+    url: https://github.com/natefaubion/purescript-node-glob-basic.git
+    rev: d20f2866c3bb472c68848be5b153e28933c07a38
+    dependencies:
+      - aff
+      - console
+      - effect
+      - lists
+      - maybe
+      - node-fs
+      - node-path
+      - node-process
+      - ordered-collections
+      - strings
+  node-human-signals:
+    type: registry
+    version: 1.0.0
+    integrity: sha256-HOUfMQTAIuL5AOCUlJJcKq78masah+388eQOdloYH1g=
+    dependencies:
+      - arrays
+      - control
+      - foreign-object
+      - maybe
+      - ordered-collections
+      - prelude
+  node-os:
+    type: registry
+    version: 5.1.0
+    integrity: sha256-K3gcu9AXanN1+qtk1900+Fi+CuO0s3/H/RMNRNgIzso=
+    dependencies:
+      - arrays
+      - bifunctors
+      - console
+      - control
+      - datetime
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - foreign
+      - foreign-object
+      - functions
+      - maybe
+      - node-buffer
+      - nullable
+      - partial
+      - posix-types
+      - prelude
+      - unsafe-coerce
+  node-path:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-pd82nQ+2l5UThzaxPdKttgDt7xlsgIDLpPG0yxDEdyE=
+    dependencies:
+      - effect
+  node-process:
+    type: registry
+    version: 11.2.0
+    integrity: sha256-+2MQDYChjGbVbapCyJtuWYwD41jk+BntF/kcOTKBMVs=
+    dependencies:
+      - effect
+      - foreign
+      - foreign-object
+      - maybe
+      - node-event-emitter
+      - node-streams
+      - posix-types
+      - prelude
+      - unsafe-coerce
+  node-streams:
+    type: registry
+    version: 9.0.0
+    integrity: sha256-2n6dq7YWleTDmD1Kur/ul7Cn08IvWrScgPf+0PgX2TQ=
+    dependencies:
+      - aff
+      - effect
+      - either
+      - exceptions
+      - node-buffer
+      - node-event-emitter
+      - nullable
+      - prelude
+  nonempty:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  now:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=
+    dependencies:
+      - datetime
+      - effect
+  nullable:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=
+    dependencies:
+      - effect
+      - functions
+      - maybe
+  numbers:
+    type: registry
+    version: 9.0.1
+    integrity: sha256-/9M6aeMDBdB4cwYDeJvLFprAHZ49EbtKQLIJsneXLIk=
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: registry
+    version: 3.1.1
+    integrity: sha256-boSYHmlz4aSbwsNN4VxiwCStc0t+y1F7BXmBS+1JNtI=
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  parsing:
+    type: registry
+    version: 10.2.0
+    integrity: sha256-ZDIdMFAKkst57x6BVa1aUWJnS8smoZnXsZ339Aq1mPA=
+    dependencies:
+      - arrays
+      - control
+      - effect
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - identity
+      - integers
+      - lazy
+      - lists
+      - maybe
+      - newtype
+      - nullable
+      - numbers
+      - partial
+      - prelude
+      - st
+      - strings
+      - tailrec
+      - transformers
+      - tuples
+      - unfoldable
+      - unicode
+      - unsafe-coerce
+  partial:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
+    dependencies: []
+  posix-types:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-ZfFz8RR1lee/o/Prccyeut3Q+9tYd08mlR72sIh6GzA=
+    dependencies:
+      - maybe
+      - prelude
+  prelude:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
+    dependencies: []
+  profunctor:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  profunctor-lenses:
+    type: registry
+    version: 8.0.0
+    integrity: sha256-K7f29rHRHgVSb2Y/PaSKtfYPriP6n87BJNO7EhsZHas=
+    dependencies:
+      - arrays
+      - bifunctors
+      - const
+      - control
+      - distributive
+      - either
+      - foldable-traversable
+      - foreign-object
+      - functors
+      - identity
+      - lists
+      - maybe
+      - newtype
+      - ordered-collections
+      - partial
+      - prelude
+      - profunctor
+      - record
+      - transformers
+      - tuples
+  record:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-Za5U85bTRJEfGK5Sk4hM41oXy84YQI0I8TL3WUn1Qzg=
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  transformers:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
+    dependencies: []
+  typelevel-prelude:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-uFF2ph+vHcQpfPuPf2a3ukJDFmLhApmkpTMviHIWgJM=
+    dependencies:
+      - prelude
+      - type-equality
+  unfoldable:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unicode:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-QJnTVZpmihEAUiMeYrfkusVoziJWp2hJsgi9bMQLue8=
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - strings
+  unsafe-coerce:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
+    dependencies: []
+  unsafe-reference:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zU7BhfJU14nXQRZG9iADsp0mSiKhz07OcKyjRB2YT+Y=
+    dependencies:
+      - prelude

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -175,7 +175,7 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
 
   Accessor e (GetProp i) ->
     S.runUncurriedFn
-      (S.Identifier $ rtPrefixed "object-ref")
+      (S.Identifier $ rtPrefixed "record-ref")
       [ codegenExpr codegenEnv e
       , S.recordLabel i
       ]

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -3,6 +3,7 @@ module PureScript.Backend.Chez.Syntax where
 import Prelude
 
 import Data.Argonaut as Json
+import Data.Array (foldr)
 import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Array.NonEmpty as NonEmptyArray
@@ -136,7 +137,7 @@ record r = do
       , recordLabel k
       , v
       ]
-  List $ [ Identifier $ rtPrefixed "make-object" ] <> (field <$> r)
+  List $ [ Identifier $ scmPrefixed "list" ] <> (field <$> r)
 
 quote :: ChezExpr -> ChezExpr
 quote e = app (Identifier $ scmPrefixed "quote") e
@@ -169,14 +170,9 @@ recordAccessor expr name field =
 recordUpdate :: ChezExpr -> Array (Prop ChezExpr) -> ChezExpr
 recordUpdate h f = do
   let
-    field :: Prop ChezExpr -> ChezExpr
-    field (Prop k v) =
-      List
-        [ Identifier $ rtPrefixed "object-set!"
-        , Identifier "$record"
-        , recordLabel k
-        , v
-        ]
-  Let false
-    (NonEmptyArray.singleton (Tuple "$record" (List [ Identifier $ rtPrefixed "object-copy", h ])))
-    (List $ [ Identifier $ scmPrefixed "begin" ] <> (field <$> f) <> [ Identifier "$record" ])
+    field :: Prop ChezExpr -> ChezExpr -> ChezExpr
+    field (Prop k v) rest =
+      List [ Identifier $ scmPrefixed "cons"
+           , List [ Identifier $ scmPrefixed "cons", recordLabel k, v ]
+           , rest ]
+  foldr field h f

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -172,7 +172,9 @@ recordUpdate h f = do
   let
     field :: Prop ChezExpr -> ChezExpr -> ChezExpr
     field (Prop k v) rest =
-      List [ Identifier $ scmPrefixed "cons"
-           , List [ Identifier $ scmPrefixed "cons", recordLabel k, v ]
-           , rest ]
+      List
+        [ Identifier $ scmPrefixed "cons"
+        , List [ Identifier $ scmPrefixed "cons", recordLabel k, v ]
+        , rest
+        ]
   foldr field h f

--- a/test-snapshots/spago.lock
+++ b/test-snapshots/spago.lock
@@ -108,48 +108,48 @@ workspace:
     content:
       arrays:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: arrays
       assert:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: assert
       bifunctors: 6.0.0
       catenable-lists: 7.0.0
       console:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: console
       const: 6.0.0
       contravariant: 6.0.0
       control:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: control
       distributive: 6.0.0
       effect:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: effect
       either: 6.1.0
       enums:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: enums
       exceptions:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: exceptions
       exists: 6.0.0
       filterable: 5.0.0
       foldable-traversable:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: foldable-traversable
       free: 7.1.0
       functions:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: functions
         dependencies:
           - prelude
@@ -158,45 +158,45 @@ workspace:
       identity: 6.0.0
       integers:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: integers
       invariant: 6.0.0
       lazy:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: lazy
       lists: 7.0.0
       maybe: 6.0.0
       minibench:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: minibench
       newtype: 5.0.0
       nonempty: 7.0.0
       numbers:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: numbers
       ordered-collections: 3.1.1
       orders: 6.0.0
       parallel: 7.0.0
       partial:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: partial
         dependencies: []
       prelude:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: prelude
       profunctor: 6.0.0
       record:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: record
       refs:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: refs
         dependencies:
           - effect
@@ -205,7 +205,7 @@ workspace:
       semirings: 7.0.0
       st:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: st
       tailrec: 6.1.0
       transformers: 6.0.0
@@ -213,24 +213,20 @@ workspace:
       type-equality: 4.0.1
       unfoldable:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: unfoldable
       unsafe-coerce:
         git: https://github.com/purescm/purescript-core.git
-        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        ref: 154d77119aa25b70f07f4b880dcba41ed811a852
         subdir: unsafe-coerce
         dependencies: []
       validation: 6.0.0
-  extra_packages:
-    prelude:
-      path: ../../core-mono/prelude
-    record:
-      path: ../../core-mono/record
+  extra_packages: {}
 packages:
   arrays:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: arrays
     dependencies:
       - bifunctors
@@ -250,7 +246,7 @@ packages:
   assert:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: assert
     dependencies:
       - console
@@ -281,7 +277,7 @@ packages:
   console:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: console
     dependencies:
       - effect
@@ -307,7 +303,7 @@ packages:
   control:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: control
     dependencies:
       - newtype
@@ -325,7 +321,7 @@ packages:
   effect:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: effect
     dependencies:
       - prelude
@@ -341,7 +337,7 @@ packages:
   enums:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: enums
     dependencies:
       - control
@@ -357,7 +353,7 @@ packages:
   exceptions:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: exceptions
     dependencies:
       - effect
@@ -384,7 +380,7 @@ packages:
   foldable-traversable:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: foldable-traversable
     dependencies:
       - bifunctors
@@ -420,7 +416,7 @@ packages:
   functions:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: functions
     dependencies:
       - prelude
@@ -469,7 +465,7 @@ packages:
   integers:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: integers
     dependencies:
       - maybe
@@ -485,7 +481,7 @@ packages:
   lazy:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: lazy
     dependencies:
       - control
@@ -522,7 +518,7 @@ packages:
   minibench:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: minibench
     dependencies:
       - console
@@ -553,7 +549,7 @@ packages:
   numbers:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: numbers
     dependencies:
       - functions
@@ -600,12 +596,14 @@ packages:
   partial:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: partial
     dependencies: []
   prelude:
-    type: local
-    path: ../../core-mono/prelude
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
+    subdir: prelude
     dependencies: []
   profunctor:
     type: registry
@@ -621,8 +619,10 @@ packages:
       - prelude
       - tuples
   record:
-    type: local
-    path: ../../core-mono/record
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
+    subdir: record
     dependencies:
       - functions
       - prelude
@@ -630,7 +630,7 @@ packages:
   refs:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: refs
     dependencies:
       - effect
@@ -653,7 +653,7 @@ packages:
   st:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: st
     dependencies:
       - partial
@@ -708,7 +708,7 @@ packages:
   unfoldable:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: unfoldable
     dependencies:
       - foldable-traversable
@@ -719,7 +719,7 @@ packages:
   unsafe-coerce:
     type: git
     url: https://github.com/purescm/purescript-core.git
-    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    rev: 154d77119aa25b70f07f4b880dcba41ed811a852
     subdir: unsafe-coerce
     dependencies: []
   validation:

--- a/test-snapshots/spago.lock
+++ b/test-snapshots/spago.lock
@@ -1,0 +1,735 @@
+workspace:
+  packages:
+    purescm-snapshots:
+      path: ./
+      dependencies:
+        - arrays
+        - assert
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - filterable
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - lazy
+        - lists
+        - maybe
+        - minibench
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - record
+        - refs
+        - safe-coerce
+        - semirings
+        - st
+        - tailrec
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+        - validation
+      test_dependencies: []
+      build_plan:
+        - arrays
+        - assert
+        - bifunctors
+        - catenable-lists
+        - console
+        - const
+        - contravariant
+        - control
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - filterable
+        - foldable-traversable
+        - free
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - lazy
+        - lists
+        - maybe
+        - minibench
+        - newtype
+        - nonempty
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - record
+        - refs
+        - safe-coerce
+        - semirings
+        - st
+        - tailrec
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+        - validation
+  package_set:
+    address:
+      path: ../package-sets/1.0.0.json
+    compiler: ">=0.15.10 <0.16.0"
+    content:
+      arrays:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: arrays
+      assert:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: assert
+      bifunctors: 6.0.0
+      catenable-lists: 7.0.0
+      console:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: console
+      const: 6.0.0
+      contravariant: 6.0.0
+      control:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: control
+      distributive: 6.0.0
+      effect:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: effect
+      either: 6.1.0
+      enums:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: enums
+      exceptions:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: exceptions
+      exists: 6.0.0
+      filterable: 5.0.0
+      foldable-traversable:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: foldable-traversable
+      free: 7.1.0
+      functions:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: functions
+        dependencies:
+          - prelude
+      functors: 5.0.0
+      gen: 4.0.0
+      identity: 6.0.0
+      integers:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: integers
+      invariant: 6.0.0
+      lazy:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: lazy
+      lists: 7.0.0
+      maybe: 6.0.0
+      minibench:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: minibench
+      newtype: 5.0.0
+      nonempty: 7.0.0
+      numbers:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: numbers
+      ordered-collections: 3.1.1
+      orders: 6.0.0
+      parallel: 7.0.0
+      partial:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: partial
+        dependencies: []
+      prelude:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: prelude
+      profunctor: 6.0.0
+      record:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: record
+      refs:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: refs
+        dependencies:
+          - effect
+          - prelude
+      safe-coerce: 2.0.0
+      semirings: 7.0.0
+      st:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: st
+      tailrec: 6.1.0
+      transformers: 6.0.0
+      tuples: 7.0.0
+      type-equality: 4.0.1
+      unfoldable:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: unfoldable
+      unsafe-coerce:
+        git: https://github.com/purescm/purescript-core.git
+        ref: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+        subdir: unsafe-coerce
+        dependencies: []
+      validation: 6.0.0
+  extra_packages:
+    prelude:
+      path: ../../core-mono/prelude
+    record:
+      path: ../../core-mono/record
+packages:
+  arrays:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: arrays
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - functions
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - safe-coerce
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  assert:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: assert
+    dependencies:
+      - console
+      - effect
+      - prelude
+  bifunctors:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  catenable-lists:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-76vYENhwF4BWTBsjeLuErCH2jqVT4M3R1HX+4RwSftA=
+    dependencies:
+      - control
+      - foldable-traversable
+      - lists
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  console:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: console
+    dependencies:
+      - effect
+      - prelude
+  const:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: control
+    dependencies:
+      - newtype
+      - prelude
+  distributive:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: effect
+    dependencies:
+      - prelude
+  either:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: enums
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: exceptions
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
+    dependencies:
+      - unsafe-coerce
+  filterable:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-cCojJHRnTmpY1j1kegI4CFwghdQ2Fm/8dzM8IlC+lng=
+    dependencies:
+      - arrays
+      - either
+      - foldable-traversable
+      - identity
+      - lists
+      - ordered-collections
+  foldable-traversable:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: foldable-traversable
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  free:
+    type: registry
+    version: 7.1.0
+    integrity: sha256-JAumgEsGSzJCNLD8AaFvuX7CpqS5yruCngi6yI7+V5k=
+    dependencies:
+      - catenable-lists
+      - control
+      - distributive
+      - either
+      - exists
+      - foldable-traversable
+      - invariant
+      - lazy
+      - maybe
+      - prelude
+      - tailrec
+      - transformers
+      - tuples
+      - unsafe-coerce
+  functions:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: functions
+    dependencies:
+      - prelude
+  functors:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: integers
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
+    dependencies:
+      - control
+      - prelude
+  lazy:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: lazy
+    dependencies:
+      - control
+      - effect
+      - foldable-traversable
+      - invariant
+      - prelude
+  lists:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  minibench:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: minibench
+    dependencies:
+      - console
+      - effect
+      - integers
+      - numbers
+      - partial
+      - prelude
+      - refs
+  newtype:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  numbers:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: numbers
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: registry
+    version: 3.1.1
+    integrity: sha256-boSYHmlz4aSbwsNN4VxiwCStc0t+y1F7BXmBS+1JNtI=
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: partial
+    dependencies: []
+  prelude:
+    type: local
+    path: ../../core-mono/prelude
+    dependencies: []
+  profunctor:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  record:
+    type: local
+    path: ../../core-mono/record
+    dependencies:
+      - functions
+      - prelude
+      - unsafe-coerce
+  refs:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: refs
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
+    dependencies:
+      - unsafe-coerce
+  semirings:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-2qGNMxVYns7RJxZd1uGtJbGTeVl/6Ozsz9OM5gRM61A=
+    dependencies:
+      - foldable-traversable
+      - lists
+      - newtype
+      - prelude
+  st:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: st
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  tailrec:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  transformers:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
+    dependencies: []
+  unfoldable:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: unfoldable
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: git
+    url: https://github.com/purescm/purescript-core.git
+    rev: 67a140e5e7dd4129c4fc81b08a401fc56e263aa8
+    subdir: unsafe-coerce
+    dependencies: []
+  validation:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-kfFailaIW4spGxbRk4261z/RGT0Sb7Dx5f3qihy0MTw=
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - foldable-traversable
+      - newtype
+      - prelude

--- a/test-snapshots/spago.yaml
+++ b/test-snapshots/spago.yaml
@@ -56,3 +56,8 @@ workspace:
       - build
   package_set:
     path: ../package-sets/1.0.0.json
+  extra_packages:
+    prelude:
+      path: ../../core-mono/prelude
+    record:
+      path: ../../core-mono/record

--- a/test-snapshots/spago.yaml
+++ b/test-snapshots/spago.yaml
@@ -56,8 +56,3 @@ workspace:
       - build
   package_set:
     path: ../package-sets/1.0.0.json
-  extra_packages:
-    prelude:
-      path: ../../core-mono/prelude
-    record:
-      path: ../../core-mono/record

--- a/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-input/Snapshot.Literals.Record.ss
@@ -7,7 +7,7 @@
 
   (define unsafeGetNotFound
     (lambda (r)
-      (rt:object-ref r "not-found")))
+      (rt:record-ref r 'not-found)))
 
 
   )

--- a/test-snapshots/src/snapshots-output/Snapshot.List.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.List.ss
@@ -19,7 +19,7 @@
     (prefix (Test.Assert lib) Test.Assert.))
 
   (scm:define show
-    (rt:object-ref (Data.List.Types.showList Data.Show.showInt) (scm:string->symbol "show")))
+    (rt:record-ref (Data.List.Types.showList Data.Show.showInt) (scm:string->symbol "show")))
 
   (scm:define xs
     (scm:cons 1 (scm:quote ())))

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -32,7 +32,7 @@
 
   (scm:define recordAccess
     (scm:lambda (v0)
-      (rt:object-ref v0 (scm:string->symbol "fooBarBaz"))))
+      (rt:record-ref v0 (scm:string->symbol "fooBarBaz"))))
 
   (scm:define main
     (scm:let*
@@ -44,7 +44,7 @@
         (scm:lambda ()
           (scm:let*
             ([_ (_4)]
-             [_ ((Test.Assert.assert (scm:fx=? (rt:object-ref t2 (scm:string->symbol "anotherField")) 42)))]
+             [_ ((Test.Assert.assert (scm:fx=? (rt:record-ref t2 (scm:string->symbol "anotherField")) 42)))]
              [_ ((Test.Assert.assert (scm:fx=? (recordAccess s1) 10)))]
              [_ ((Test.Assert.assert (scm:fx=? (recordAccess r0) 5)))]
              [_ ((Test.Assert.assert (scm:fx=? (recordAccess u3) minusTwo)))])

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -19,13 +19,12 @@
     (Snapshot.Literals.Record foreign))
 
   (scm:define insert
-    (((Record.insert (rt:make-object (scm:cons (scm:string->symbol "reflectSymbol") (scm:lambda (_)
+    (((Record.insert (scm:list (scm:cons (scm:string->symbol "reflectSymbol") (scm:lambda (_)
       "anotherField")))) (scm:gensym "purs-undefined")) (scm:gensym "purs-undefined")))
 
   (scm:define recordUpdate
     (scm:lambda (v0)
-      (scm:let ([$record (rt:object-copy v0)])
-        (scm:begin (rt:object-set! $record (scm:string->symbol "fooBarBaz") 10) $record))))
+      (scm:cons (scm:cons (scm:string->symbol "fooBarBaz") 10) v0)))
 
   (scm:define recordAddField
     (scm:lambda (_)
@@ -37,10 +36,10 @@
 
   (scm:define main
     (scm:let*
-      ([r0 (rt:make-object (scm:cons (scm:string->symbol "fooBarBaz") 5))]
+      ([r0 (scm:list (scm:cons (scm:string->symbol "fooBarBaz") 5))]
        [s1 (recordUpdate r0)]
        [t2 ((recordAddField (scm:gensym "purs-undefined")) s1)]
-       [u3 (rt:make-object (scm:cons (scm:string->symbol "fooBarBaz") minusTwo))]
+       [u3 (scm:list (scm:cons (scm:string->symbol "fooBarBaz") minusTwo))]
        [_4 (Test.Assert.assert (scm:fx=? (recordAccess t2) 10))])
         (scm:lambda ()
           (scm:let*

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.ss
@@ -21,10 +21,10 @@
     "string")
 
   (scm:define record2
-    (rt:make-object (scm:cons (scm:string->symbol "foo") "bar")))
+    (scm:list (scm:cons (scm:string->symbol "foo") "bar")))
 
   (scm:define record
-    (rt:make-object))
+    (scm:list))
 
   (scm:define number
     2.0)

--- a/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
@@ -13,7 +13,7 @@
 
   (scm:define testCase
     (scm:lambda (dictRing0)
-      (rt:object-ref ((rt:object-ref dictRing0 (scm:string->symbol "Semiring0")) (scm:gensym "purs-undefined")) (scm:string->symbol "add"))))
+      (rt:record-ref ((rt:record-ref dictRing0 (scm:string->symbol "Semiring0")) (scm:gensym "purs-undefined")) (scm:string->symbol "add"))))
 
   (scm:define main
     (Test.Assert.assert (scm:fx=? (((testCase Data.Ring.ringInt) 1) 1) 2))))

--- a/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
@@ -104,7 +104,7 @@
             (scm:string-append ((rt:object-ref dictNormal0 (scm:string->symbol "normal")) a2) ((rt:object-ref dictNormal11 (scm:string->symbol "normal")) b3)))))))
 
   (scm:define instanceName$p
-    (rt:make-object (scm:cons (scm:string->symbol "normal") (scm:lambda (v0)
+    (scm:list (scm:cons (scm:string->symbol "normal") (scm:lambda (v0)
       (scm:cond
         [(F1? v0) "F1"]
         [(F2? v0) "F2"]

--- a/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
@@ -94,14 +94,14 @@
 
   (scm:define normal
     (scm:lambda (dict0)
-      (rt:object-ref dict0 (scm:string->symbol "normal"))))
+      (rt:record-ref dict0 (scm:string->symbol "normal"))))
 
   (scm:define useNormal
     (scm:lambda (dictNormal0)
       (scm:lambda (dictNormal11)
         (scm:lambda (a2)
           (scm:lambda (b3)
-            (scm:string-append ((rt:object-ref dictNormal0 (scm:string->symbol "normal")) a2) ((rt:object-ref dictNormal11 (scm:string->symbol "normal")) b3)))))))
+            (scm:string-append ((rt:record-ref dictNormal0 (scm:string->symbol "normal")) a2) ((rt:record-ref dictNormal11 (scm:string->symbol "normal")) b3)))))))
 
   (scm:define instanceName$p
     (scm:list (scm:cons (scm:string->symbol "normal") (scm:lambda (v0)
@@ -115,11 +115,11 @@
 
   (scm:define ignore
     (scm:lambda (dict0)
-      (rt:object-ref dict0 (scm:string->symbol "ignore"))))
+      (rt:record-ref dict0 (scm:string->symbol "ignore"))))
 
   (scm:define useClass
     (scm:lambda (dictClassName$p0)
-      (rt:object-ref dictClassName$p0 (scm:string->symbol "ignore"))))
+      (rt:record-ref dictClassName$p0 (scm:string->symbol "ignore"))))
 
   (scm:define foo$poo
     "foo'oo")
@@ -144,8 +144,8 @@
 
   (scm:define classMember$p
     (scm:lambda (dict0)
-      (rt:object-ref dict0 (scm:string->symbol "classMember'"))))
+      (rt:record-ref dict0 (scm:string->symbol "classMember'"))))
 
   (scm:define useMember
     (scm:lambda (dictClassMember0)
-      (rt:object-ref dictClassMember0 (scm:string->symbol "classMember'")))))
+      (rt:record-ref dictClassMember0 (scm:string->symbol "classMember'")))))

--- a/vendor/purs/runtime.ss
+++ b/vendor/purs/runtime.ss
@@ -4,10 +4,10 @@
   (purs runtime)
   (export
     list-cons
-    object-set
-    object-ref
-    object-has
-    object-delete
+    record-set
+    record-ref
+    record-has
+    record-remove
     array-length
     array-ref
     make-array
@@ -62,28 +62,29 @@
   ; Records
   ;
 
-  (define (object-has alist k)
-    (let ([res (assq k alist)])
+  (define (record-has rec k)
+    (let ([res (assq k rec)])
       (not (eq? res #f))))
 
-  (define (object-ref alist k)
-    (let ([res (assq k alist)])
+  (define (record-ref rec k)
+    (let ([res (assq k rec)])
       (if (not res)
         (raise-continuable
           (condition
             (make-error)
-            (make-message-condition (format "Object key ~a not defined in ~a" k alist))))
+            (make-message-condition (format "Record key ~a not defined in ~a" k rec))))
         (cdr res))))
 
-  (define (object-delete xs k)
-    (if (null? xs)
-      xs
-      (if (eq? (caar xs) k)
-        (cdr xs)
-        (cons (car xs) (object-delete (cdr xs) k)))))
+  (define (record-remove rec k)
+    (if (null? rec)
+      rec
+      (if (eq? (caar rec) k)
+        (cdr rec)
+        (cons (car rec) (record-remove (cdr rec) k)))))
 
-  (define (object-set alist k v)
-    (cons (cons k v) (object-delete alist k)))
+  (define (record-set rec k v)
+    (cons (cons k v) (record-remove rec k)))
+
 
   ;
   ; Lists

--- a/vendor/purs/runtime.ss
+++ b/vendor/purs/runtime.ss
@@ -19,6 +19,10 @@
     (chezscheme)
     (prefix (purs runtime srfi :214) srfi:214:))
 
+  ;
+  ; Booleans
+  ;
+
   (define boolean->integer
     (lambda (x)
       (if x 1 0)))
@@ -43,15 +47,24 @@
       (lambda (y)
         (fx<? (boolean->integer x) (boolean->integer y)))))
 
+  ;
+  ; Arrays
+  ;
+
   (define make-array srfi:214:flexvector)
 
   (define array-ref srfi:214:flexvector-ref)
 
   (define array-length srfi:214:flexvector-length)
 
+
+  ;
+  ; Records
+  ;
+
   (define (object-has alist k)
     (let ([res (assq k alist)])
-      (if (not res) #f #t)))
+      (not (eq? res #f))))
 
   (define (object-ref alist k)
     (let ([res (assq k alist)])
@@ -71,6 +84,10 @@
 
   (define (object-set alist k v)
     (cons (cons k v) (object-delete alist k)))
+
+  ;
+  ; Lists
+  ;
 
   (define list-cons
     (lambda (x) (lambda (xs) (cons x xs))))


### PR DESCRIPTION
Using hash-tables is expensive for record literals and records are always so small that assoc lists are just faster. In my benchmarks testing the CST parser this is around 30% faster.

There is no way to allocate a hash-table "statically" so that Chez would allocate a fixed size hash-table - we are currently populating record literals in a loop. There is a scheme solution for static records: scheme records! But we can't use those as we don't have the record types available at compile time.

Update to core libs https://github.com/purescm/purescript-core/pull/1