### PR TITLE
Return with correct exit code when compilation fails

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -216,6 +216,7 @@ runBundle cliRoot args = do
     arguments = [ "-q", "--libdirs", libDirs ]
   res <- evalScheme arguments $ Array.fold
     [ "(top-level-program (import (chezscheme))"
+    -- Catch compilation errors so that we exit with an error code
     , "  (with-exception-handler (lambda (e) (display-condition e (console-error-port)) (newline (console-error-port)) (exit -1))"
     , "    (lambda ()"
     , "      (compile-profile #f)"
@@ -237,6 +238,7 @@ runRun cliRoot args = do
     libDirs = runtimePath <> ":" <> args.libDir <> ":"
     arguments = [ "-q", "--libdirs", libDirs ]
   res <- evalScheme arguments $ Array.fold
+    -- Catch errors so that we exit with an error code
     [ "(base-exception-handler (lambda (e)"
     , "  (display-condition e (console-error-port))"
     , "  (newline (console-error-port))"


### PR DESCRIPTION
This was a recent change which I'm now reverting. Basically this fixes the case when there is an error during compilation, either when AOT compiling or when compiling as part of the `run` command. I had forgotten why I put these error handlers in there, but it was this case. We should probably add a test suite for the CLI at some point.