### PR TITLE
Inline `st`

### DIFF
--- a/src/PureScript/Backend/Chez/Builder.purs
+++ b/src/PureScript/Backend/Chez/Builder.purs
@@ -60,10 +60,10 @@ basicBuildMain options = do
         { directives: Map.union externalDirectives (parseDirectiveFile defaultDirectives).directives
         , foreignSemantics: coreForeignSemantics # Map.filterKeys \(Qualified mod _) -> mod
             `notElem`
-              -- Filter out the PrimEffect
-              [ Just (ModuleName "Effect.Ref")
-              , Just (ModuleName "Control.Monad.ST.Internal")
-              ]
+              -- `Effect.Ref.modify` is implemented as a thread-safe operation
+              -- in the `refs` package. Note that `Control.Monad.ST.Internal`
+              -- will still be inlined.
+              [ Just (ModuleName "Effect.Ref") ]
         , onCodegenModule: options.onCodegenModule
         , onPrepareModule: options.onPrepareModule
         , traceIdents: Set.empty

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -28,7 +28,7 @@ import PureScript.Backend.Chez.Syntax as S
 import PureScript.Backend.Optimizer.Convert (BackendModule, BackendBindingGroup)
 import PureScript.Backend.Optimizer.CoreFn (Ident(..), Literal(..), ModuleName(..), Qualified(..))
 import PureScript.Backend.Optimizer.Semantics (NeutralExpr)
-import PureScript.Backend.Optimizer.Syntax (BackendAccessor(..), BackendOperator(..), BackendOperator1(..), BackendOperator2(..), BackendOperatorNum(..), BackendOperatorOrd(..), BackendSyntax(..), Level(..), Pair(..))
+import PureScript.Backend.Optimizer.Syntax (BackendAccessor(..), BackendEffect(..), BackendOperator(..), BackendOperator1(..), BackendOperator2(..), BackendOperatorNum(..), BackendOperatorOrd(..), BackendSyntax(..), Level(..), Pair(..))
 import Safe.Coerce (coerce)
 
 type CodegenEnv =
@@ -344,6 +344,8 @@ codegenChain chainMode codegenEnv = collect []
   -- `expression` has type `Effect ..`, so we can confidently unthunk here
   codegenEffectBind :: NeutralExpr -> ChezExpr
   codegenEffectBind expression = case unwrap expression of
+    PrimEffect e' ->
+      codegenPrimEffect codegenEnv e'
     UncurriedEffectApp f p ->
       S.runUncurriedFn (codegenExpr codegenEnv f) (codegenExpr codegenEnv <$> p)
     _ ->
@@ -364,6 +366,8 @@ codegenChain chainMode codegenEnv = collect []
       collect (Array.snoc bindings $ Tuple (toChezIdent i l) (codegenExpr codegenEnv v)) e'
     EffectPure e' | chainMode.effect ->
       finish false bindings (codegenExpr codegenEnv e')
+    PrimEffect e' | chainMode.effect ->
+      finish false bindings (codegenPrimEffect codegenEnv e')
     EffectBind i l v e' | chainMode.effect ->
       collect
         (Array.snoc bindings $ Tuple (toChezIdent i l) (codegenEffectBind v))
@@ -427,7 +431,6 @@ codegenPrimOp codegenEnv@{ currentModule } = case _ of
           OpGte -> comparisonExpression ">=?"
           OpLt -> comparisonExpression "<?"
           OpLte -> comparisonExpression "<=?"
-
     in
       case o of
         OpArrayIndex ->
@@ -499,3 +502,20 @@ codegenPrimOp codegenEnv@{ currentModule } = case _ of
                 OpLt -> comparisonExpression "<?"
                 OpLte -> comparisonExpression "<=?"
           makeStringComparison o'
+
+codegenPrimEffect :: CodegenEnv -> BackendEffect NeutralExpr -> ChezExpr
+codegenPrimEffect codegenEnv = case _ of
+  EffectRefNew v ->
+    S.app (S.Identifier $ scmPrefixed "box") (codegenExpr codegenEnv v)
+  EffectRefRead r ->
+    S.app (S.Identifier $ scmPrefixed "unbox") (codegenExpr codegenEnv r)
+  EffectRefWrite r v ->
+    S.List
+      [ S.Identifier $ scmPrefixed "begin"
+      , S.List
+          [ S.Identifier $ scmPrefixed "set-box!"
+          , codegenExpr codegenEnv r
+          , codegenExpr codegenEnv v
+          ]
+      , S.List [ S.Identifier $ scmPrefixed "unbox", codegenExpr codegenEnv r ]
+      ]


### PR DESCRIPTION
This partly reverts 45bce2e because we can still inline `st` even though `Effect.Ref` is no longer inlined. The result is that `Effect.Ref` is thread-safe but `ST` is not.

This is important performance-wise. We can later improve the ST inlining by removing the `box` indirection and use normal variables.