### PR TITLE
Optimize string operations by using a "cursor"

### DIFF
--- a/vendor/purs/runtime/pstring-buffer.ss
+++ b/vendor/purs/runtime/pstring-buffer.ss
@@ -101,6 +101,5 @@
               ;; one-word encoding
               [else (begin (string-set! out char-i (integer->char w1)) (loop (fx+ i 1) (fx1+ char-i)))]))
           (begin (string-truncate! out char-i) out)))))
-
   )
 

--- a/vendor/purs/runtime/pstring-test.ss
+++ b/vendor/purs/runtime/pstring-test.ss
@@ -103,12 +103,14 @@
       (assert (fx=? 1 (pstring-index-of (lit "zza") (lit "za"))))
       (assert (fx=? 0 (pstring-index-of (lit "𝕒𝕓𝕔") (lit "𝕒"))))
       (assert (fx=? 2 (pstring-index-of (lit "𝕒𝕓𝕔") (lit "𝕓"))))
+      (assert (fx=? 1 (pstring-index-of (lit "11112") (lit "1112"))))
 
       ;; last-index-of
       (assert (fx=? 7 (pstring-last-index-of (lit "foo bar") (lit ""))))
       (assert (fx=? 0 (pstring-last-index-of (lit "") (lit ""))))
       (assert (not (pstring-index-of (lit "foo bar") (lit "baz"))))
       (assert (fx=? 8 (pstring-last-index-of (lit "foo bar foo") (lit "foo"))))
+      (assert (fx=? 6 (pstring-last-index-of (lit "1112 1112") (lit "112"))))
 
       ;; comparisons
       (assert (pstring=? (lit "abc") (lit "abc")))
@@ -392,6 +394,16 @@
                 pstring=?
                 (pstring-regex-split (pstring-make-regex (lit "🍔")) (lit "𝕒🍔𝕓🍔𝕔🍔de"))
                 (srfi:214:flexvector (lit "𝕒") (lit "𝕓") (lit "𝕔") (lit "de"))))
+
+
+      (assert (eqv? (eof-object) (pstring-cursor-peek-char (pstring->cursor (lit "")))))
+      (assert (eqv? #\f (pstring-cursor-peek-char (pstring->cursor (lit "foo")))))
+
+      (let ([cur (pstring->cursor (lit "foo"))])
+        (assert (eqv? #\f (pstring-cursor-read-char cur)))
+        (assert (eqv? #\o (pstring-cursor-read-char cur)))
+        (assert (eqv? #\o (pstring-cursor-read-char cur)))
+        (assert (eqv? (eof-object) (pstring-cursor-read-char cur))))
 
       (display "All good!\n")
       ))


### PR DESCRIPTION
This optimizes many of the string operations by using a new abstraction called _cursor_ that is much like a Scheme port but that works better for our use cases. Cursor has an imperative API that reduces allocations significantly compared to unconsing.

While removing the uses of `pstring-uncons-code-unit` I also found a bug in both `pstring-index-of` and `pstring-last-index-of` where the match wasn't found at all if the string and pattern shared a longer prefix.

This also changes how we decode code points from the UTF-16 bytevector: we now replace lone surrogates with the Unicode Replacement Character. This way we can implement `cursor-read-char` in terms of `cursor-read-code-point`.

Why not use Scheme ports for fast iteration over String? We could use [`make-custom-textual-input-port`](https://scheme.com/tspl4/io.html#./io:s42) but it's API assumes you want to allocate a Scheme string every time you read from the port. This would work since we only ever need the first character from the port, but is not optimal for this use case. We also don't currently need the `port` abstraction for anything.

Fix for `strings` https://github.com/purescm/purescript-core/pull/10