### PR TITLE
Print a stack trace

### DIFF
--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -67,7 +67,11 @@ loadModuleMain options = do
   when options.hasMain do
     spawned.stdin.writeUtf8End $ Array.fold
       [ "(base-exception-handler (lambda (e) (display-condition e (console-error-port)) (newline (console-error-port)) (exit -1)))"
-      , "(top-level-program (import (" <> options.moduleName <> " lib)) (main))"
+      , "(top-level-program (import (only (chezscheme) base-exception-handler exit lambda)"
+      , "                           (" <> options.moduleName <> " lib)"
+      , "                           (only (purs runtime stack-trace) print-stack-trace))"
+      , "  (base-exception-handler (lambda (e) (print-stack-trace e) (exit -1)))"
+      , "  (main))"
       ]
   spawned.stdout.pipeToParentStdout
   spawned.stderr.pipeToParentStderr

--- a/vendor/purs/runtime/stack-trace.ss
+++ b/vendor/purs/runtime/stack-trace.ss
@@ -1,0 +1,29 @@
+(library (purs runtime stack-trace)
+  (export print-stack-trace)
+  (import (chezscheme))
+
+  ; Prints a stack trace from an exception
+  ; 
+  ; See discussion: <https://github.com/cisco/ChezScheme/issues/128>
+  (define (print-stack-trace e)
+
+    (define (get-func-name c)
+      (let ([cc ((c 'code) 'name)])
+        (if cc cc "--main--")))
+    
+    (display-condition e)
+    (newline)
+    
+    (let loop ([insp (inspect/object (condition-continuation e))])
+      (call/cc
+        (lambda (ret)
+          (when (fx>? (insp 'depth) 1)
+            (call-with-values
+              (lambda () (insp 'source-path))
+              (case-lambda
+                [(file line column)
+                  (printf "  at ~a (~a:~a,~a)\n" (get-func-name insp) file line column)]
+                [else (ret)]))
+            (loop (insp 'link)))))))
+
+  )


### PR DESCRIPTION
Prints a stack trace for caught exceptions. It will print something like this:

```
Exception: attempt to apply non-procedure #f
  at flexvector-map/index-into! (/home/antti/code/purescm/purescm/vendor/purs/runtime/srfi/:214/impl.sls:322,25)
  at f (/home/antti/code/purescm/purescm/vendor/purs/runtime/srfi/:214/impl.sls:340,5)
  at pstring-regex-replace-single (/home/antti/code/purescm/purescm/vendor/purs/runtime/pstring.ss:746,29)
  at testStringRegex (output/Test.Data.String.Regex/lib.ss:74,50)
  at main (output/Test.Data.String.Main/lib.ss:33,15)
```
