### PR TITLE
Fix string-truncate with 0 length

### DIFF
--- a/vendor/purs/runtime/pstring-buffer.ss
+++ b/vendor/purs/runtime/pstring-buffer.ss
@@ -100,6 +100,8 @@
                  (loop (fx+ i 1) (fx1+ char-i)))]
               ;; one-word encoding
               [else (begin (string-set! out char-i (integer->char w1)) (loop (fx+ i 1) (fx1+ char-i)))]))
-          (begin (string-truncate! out char-i) out)))))
+          (if (eq? len 0)
+            out
+            (string-truncate! out char-i))))))
   )
 


### PR DESCRIPTION
`string-truncate` will panic if given a length of 0, so we skip it if that's the case