### PR TITLE
Add forked lists package to package set

### DIFF
--- a/package-sets/1.0.0.json
+++ b/package-sets/1.0.0.json
@@ -79,7 +79,10 @@
       "ref": "b55c8bb976dcddf69fda2593c5707969ca1e13b4",
       "subdir": "lazy"
     },
-    "lists": "7.0.0",
+    "lists": {
+      "git": "https://github.com/purescm/purescript-lists.git",
+      "ref": "71502a132567cf7f32c2242d57b1cba2c77ebc15"
+    },
     "maybe": "6.0.0",
     "minibench": {
       "git": "https://github.com/purescm/purescript-core.git",


### PR DESCRIPTION
The fork uses Scheme native functions for some folds.

I probably just forgot to add this to the package set previously.