### PR TITLE
Use libicu for pstring-upcase and pstring-downcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Install requisites:
 
 * [`chezscheme`](https://cisco.github.io/ChezScheme/) - you should have the `scheme` command available in your `$PATH`.
 * [`libpcre2`](https://pcre2project.github.io/pcre2/) - `purescm` has a runtime dependency on the 16-bit variant of pcre2. Check your package manager for `pcre2` or `pcre2-16` or similar.
+* [`icu`](https://icu.unicode.org/) - `libicu` is used for locale-aware case conversions.
 
 You can install purescm with npm:
 

--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719931832,
-        "narHash": "sha256-0LD+KePCKKEb4CcPsTBOwf019wDtZJanjoKm1S8q3Do=",
+        "lastModified": 1723891200,
+        "narHash": "sha256-uljX21+D/DZgb9uEFFG2dkkQbPZN+ig4Z6+UCLWFVAk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0aeab749216e4c073cece5d34bc01b79e717c3e0",
+        "rev": "a0d6390cb3e82062a35d0288979c45756e481f60",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         "slimlock": "slimlock"
       },
       "locked": {
-        "lastModified": 1719849006,
-        "narHash": "sha256-0HpRwEdvAlbSka5tFLwokz2bEV+QgoGqRZ0BR/ghB6w=",
+        "lastModified": 1721913285,
+        "narHash": "sha256-NVcUJMz2bHylxLRYhgbPT/yHzGIkQJNF7y1TKKCRIM4=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "6a00f4a8fbb42e0494a57c5da99b1375721a6c4b",
+        "rev": "8b1ea117f0cfe5d81dc005c6168f17c1fd7e75ec",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
             chez = pkgs.chez.overrideAttrs (final: prev: {
               postFixup = if pkgs.stdenv.isDarwin then ''
                 install_name_tool -add_rpath ${pkgs.pcre2.out}/lib $out/bin/scheme
+                install_name_tool -add_rpath ${pkgs.icu}/lib $out/bin/scheme
               ''
               else ''
                 patchelf $out/bin/scheme --add-rpath ${pkgs.pcre2.out}/lib

--- a/flake.nix
+++ b/flake.nix
@@ -37,21 +37,23 @@
               ''
               else ''
                 patchelf $out/bin/scheme --add-rpath ${pkgs.pcre2.out}/lib
+                patchelf $out/bin/scheme --add-rpath ${pkgs.icu}/lib
               '';
             });
         in {
           default = pkgs.mkShell {
             name = "purescm";
-            packages = with pkgs; [
-              purescript-language-server
-              purs-backend-es
-              purs-bin.purs-0_15_10
-              purs-tidy
-              spago-unstable
-              nodejs-slim
-              esbuild
+            packages = [
+              pkgs.purescript-language-server
+              pkgs.purs-backend-es
+              pkgs.purs-bin.purs-0_15_10
+              pkgs.purs-tidy
+              pkgs.spago-unstable
+              pkgs.nodejs-slim
+              pkgs.esbuild
+              pkgs.pkg-config
+              pkgs.icu
               chez
-              pkg-config
             ];
           };
         });

--- a/vendor/purs/runtime/pstring.ss
+++ b/vendor/purs/runtime/pstring.ss
@@ -793,13 +793,29 @@
   ; Modifications
   ;
 
-  ; Slow downcasing that does an extra allocation to a scheme string
   (define (pstring-downcase str)
-    (string->pstring (string-downcase (pstring->string str))))
+    (let* ([src (pstring-compact! str)]
+           ; The output might be twice the length of the input in some languages
+           [dst-len (fx1+ (fx* (Slice-length src) 2))]
+           [dst (pstring-buffer-alloc dst-len)]
+           [errorcode (foreign-alloc (foreign-sizeof 'int))])
+      ; ICU requires that we set the initial error code value to 0
+      (ftype-set! int () (make-ftype-pointer int errorcode) 0 0)
+      (let ([len (u_strToLower (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) "" errorcode)])
+        (foreign-free errorcode)
+        (make-Slice dst 0 len))))
 
-  ; Slow upcasing that does an extra allocation to a scheme string
   (define (pstring-upcase str)
-    (string->pstring (string-upcase (pstring->string str))))
+    (let* ([src (pstring-compact! str)]
+           ; The output might be twice the length of the input in some languages
+           [dst-len (fx1+ (fx* (Slice-length src) 2))]
+           [dst (pstring-buffer-alloc dst-len)]
+           [errorcode (foreign-alloc (foreign-sizeof 'int))])
+      ; ICU requires that we set the initial error code value to 0
+      (ftype-set! int () (make-ftype-pointer int errorcode) 0 0)
+      (let ([len (u_strToUpper (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) "" errorcode)])
+        (foreign-free errorcode)
+        (make-Slice dst 0 len))))
 
   ; Trim whitespace around the pstring
   (define (pstring-trim str)
@@ -1277,6 +1293,28 @@
     (foreign-procedure "pcre2_jit_compile_16" (uptr unsigned-32)
                        void))
 
+
+  ;
+  ; ICU bindings
+  ;
+
+  (define icu-init
+    (case (machine-type)
+      ; [(i3nt ti3nt a6nt ta6nt) (load-shared-object "libicuuc.dll")]
+      [(i3osx ti3osx a6osx ta6osx arm64osx tarm64osx) (load-shared-object "libicuuc.dylib")]
+      [(i3le ti3le a6le ta6le arm64le tarm64le) (load-shared-object "libicuuc.so")]
+      [else (error "purescm"
+                   (format "Failed to load libicuuc, machine-type ~s not supported." (machine-type)))]))
+
+  (define u_strToUpper
+    (foreign-procedure "u_strToUpper_74" ((* unsigned-16) integer-32 (* unsigned-16) integer-32 string uptr)
+                       integer-32))
+
+  (define u_strToLower
+    (foreign-procedure "u_strToLower_74" ((* unsigned-16) integer-32 (* unsigned-16) integer-32 string uptr)
+                       integer-32))
+
+
   ;
   ; Cursor
   ;
@@ -1381,6 +1419,7 @@
             ; one-word encoding
             [else w1])))
       (eof-object)))
+
 
   )
 

--- a/vendor/purs/runtime/pstring.ss
+++ b/vendor/purs/runtime/pstring.ss
@@ -802,7 +802,7 @@
            [errorcode-ptr (make-ftype-pointer int errorcode-addr)])
       ; ICU requires that we set the initial error code value to 0
       (ftype-set! int () errorcode-ptr 0 0)
-      (let* ([len (u_strToLower (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) "" errorcode-addr)]
+      (let* ([len (u_strToLower (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) 0 errorcode-addr)]
              [errorcode (ftype-ref int () (make-ftype-pointer int errorcode-addr) 0)])
         (foreign-free errorcode-addr)
         (if (not (= errorcode 0))
@@ -818,7 +818,7 @@
            [errorcode-ptr (make-ftype-pointer int errorcode-addr)])
       ; ICU requires that we set the initial error code value to 0
       (ftype-set! int () errorcode-ptr 0 0)
-      (let* ([len (u_strToUpper (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) "" errorcode-addr)]
+      (let* ([len (u_strToUpper (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) 0 errorcode-addr)]
              [errorcode (ftype-ref int () (make-ftype-pointer int errorcode-addr) 0)])
         (foreign-free errorcode-addr)
         (if (not (= errorcode 0))
@@ -1315,11 +1315,11 @@
                    (format "Failed to load libicuuc, machine-type ~s not supported." (machine-type)))]))
 
   (define u_strToUpper
-    (foreign-procedure "u_strToUpper_74" ((* unsigned-16) integer-32 (* unsigned-16) integer-32 string uptr)
+    (foreign-procedure "u_strToUpper_74" ((* unsigned-16) integer-32 (* unsigned-16) integer-32 uptr uptr)
                        integer-32))
 
   (define u_strToLower
-    (foreign-procedure "u_strToLower_74" ((* unsigned-16) integer-32 (* unsigned-16) integer-32 string uptr)
+    (foreign-procedure "u_strToLower_74" ((* unsigned-16) integer-32 (* unsigned-16) integer-32 uptr uptr)
                        integer-32))
 
 

--- a/vendor/purs/runtime/pstring.ss
+++ b/vendor/purs/runtime/pstring.ss
@@ -798,24 +798,32 @@
            ; The output might be twice the length of the input in some languages
            [dst-len (fx1+ (fx* (Slice-length src) 2))]
            [dst (pstring-buffer-alloc dst-len)]
-           [errorcode (foreign-alloc (foreign-sizeof 'int))])
+           [errorcode-addr (foreign-alloc (foreign-sizeof 'int))]
+           [errorcode-ptr (make-ftype-pointer int errorcode-addr)])
       ; ICU requires that we set the initial error code value to 0
-      (ftype-set! int () (make-ftype-pointer int errorcode) 0 0)
-      (let ([len (u_strToLower (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) "" errorcode)])
-        (foreign-free errorcode)
-        (make-Slice dst 0 len))))
+      (ftype-set! int () errorcode-ptr 0 0)
+      (let* ([len (u_strToLower (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) "" errorcode-addr)]
+             [errorcode (ftype-ref int () (make-ftype-pointer int errorcode-addr) 0)])
+        (foreign-free errorcode-addr)
+        (if (not (= errorcode 0))
+          (error "pstring-downcase" (format "error calling u_strToLower, error code ~a" errorcode))
+          (make-Slice dst 0 len)))))
 
   (define (pstring-upcase str)
     (let* ([src (pstring-compact! str)]
            ; The output might be twice the length of the input in some languages
            [dst-len (fx1+ (fx* (Slice-length src) 2))]
            [dst (pstring-buffer-alloc dst-len)]
-           [errorcode (foreign-alloc (foreign-sizeof 'int))])
+           [errorcode-addr (foreign-alloc (foreign-sizeof 'int))]
+           [errorcode-ptr (make-ftype-pointer int errorcode-addr)])
       ; ICU requires that we set the initial error code value to 0
-      (ftype-set! int () (make-ftype-pointer int errorcode) 0 0)
-      (let ([len (u_strToUpper (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) "" errorcode)])
-        (foreign-free errorcode)
-        (make-Slice dst 0 len))))
+      (ftype-set! int () errorcode-ptr 0 0)
+      (let* ([len (u_strToUpper (pstring-buffer-&ref dst 0) dst-len (slice-&ref src) (Slice-length src) "" errorcode-addr)]
+             [errorcode (ftype-ref int () (make-ftype-pointer int errorcode-addr) 0)])
+        (foreign-free errorcode-addr)
+        (if (not (= errorcode 0))
+          (error "pstring-upcase" (format "error calling u_strToUpper, error code ~a" errorcode))
+          (make-Slice dst 0 len)))))
 
   ; Trim whitespace around the pstring
   (define (pstring-trim str)

--- a/vendor/purs/runtime/test/pstring-test.ss
+++ b/vendor/purs/runtime/test/pstring-test.ss
@@ -173,6 +173,8 @@
       (assert (pstring=? (pstring-upcase (lit "")) (lit "")))
       (assert (pstring=? (pstring-upcase (lit "FOO")) (lit "FOO")))
       (assert (pstring=? (pstring-upcase (lit "foo")) (lit "FOO")))
+      (assert (pstring=? (pstring-upcase (lit "ß")) (lit "SS")))
+      (assert (pstring=? (pstring-upcase (lit "straße")) (lit "STRASSE")))
       (assert (not (pstring=? (pstring-upcase (lit "foo")) (lit "FOo"))))
 
       (assert (pstring=?


### PR DESCRIPTION
Use libicu for case conversions. No error handling yet, and uses the "default" locale.

```
Node:
String.toUpper: { mean = 3.52 μs | stddev = 5.87 μs | min = 2.28 μs | max = 61.39 μs }

Old purescm:
String.toUpper: { mean = 135.52 μs | stddev = 20.98 μs | min = 120.78 μs | max = 278.43 μs }

New purescm:
String.toUpper: { mean = 40.49 μs | stddev = 4.44 μs | min = 38.98 μs | max = 79.51 μs }
```

We are now only one order of magnitude slower than node :)

Fixes #249 