### PR TITLE
Add nix caching for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
 
       - name: Build the project
         run: |
-          nix-shell --run "spago build"
+          nix shell -c bash -c "spago build"
 
       - name: Run tests
         run: |
-          nix-shell --run "npm run test"
+          nix shell -c bash -c "npm run test"
 
       - name: Check Formatting
         run: |
-          nix-shell --run "purs-tidy check src test"
+          nix shell -c bash -c "purs-tidy check src test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
 
       - name: Build the project
         run: |
-          nix shell -c bash -c "spago build"
+          nix develop -c bash -c "spago build"
 
       - name: Run tests
         run: |
-          nix shell -c bash -c "npm run test"
+          nix develop -c bash -c "npm run test"
 
       - name: Check Formatting
         run: |
-          nix shell -c bash -c "purs-tidy check src test"
+          nix develop -c bash -c "purs-tidy check src test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,6 @@ jobs:
             .spago
             output
 
-      - name: Set up Node toolchain
-        uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-
       - name: Install Nix
         uses: cachix/install-nix-action@v22
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v22
 
+      - name: Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
       - name: Build the project
         run: |
           nix-shell --run "spago build"


### PR DESCRIPTION
Cache the nix artifacts between builds (mostly Chez) and don't install node tools (we use nix after all).