### PR TITLE
Fix pstring? implementation

### DIFF
--- a/vendor/purs/runtime/pstring.ss
+++ b/vendor/purs/runtime/pstring.ss
@@ -10,7 +10,7 @@
           pstring=?
           pstring>=?
           pstring>?
-          (rename (Slice? pstring?))
+          pstring?
           pstring->char-flexvector
           pstring->code-point-flexvector
           pstring-concat

--- a/vendor/purs/runtime/test/pstring-test.ss
+++ b/vendor/purs/runtime/test/pstring-test.ss
@@ -49,6 +49,8 @@
   (define main
     (lambda ()
 
+      (assert-all-pstring pstring?)
+
       ;; reffing
       (assert (check-raises (lambda () (pstring-ref-code-point (lit "") 0))))
       (assert (fx=? 228 (pstring-ref-code-point (lit "ä") 0)))


### PR DESCRIPTION
Somehow I had forgotten to update `pstring?` when implementing the rope. I think it was because there was a missing test for `pstring?`.