### PR TITLE
Implement lazy initialization for recursive top level bindings

### DIFF
--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -8,18 +8,21 @@ import Data.Array.NonEmpty as NEA
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Bifunctor (bimap)
 import Data.Char (toCharCode)
+import Data.Filterable (separate)
+import Data.Foldable (fold, foldMap)
 import Data.Int as Int
 import Data.Maybe (Maybe(..))
 import Data.Monoid (power)
 import Data.Newtype (unwrap, wrap)
 import Data.Number (isNaN)
+import Data.Set (Set)
 import Data.Set as Set
 import Data.String as String
 import Data.String.CodeUnits as CodeUnits
 import Data.String.Regex as R
 import Data.String.Regex.Flags as R.Flags
 import Data.String.Regex.Unsafe as R.Unsafe
-import Data.Tuple (Tuple(..), uncurry)
+import Data.Tuple (Tuple(..), fst, uncurry)
 import Data.Tuple as Tuple
 import Partial.Unsafe (unsafeCrashWith)
 import PureScript.Backend.Chez.Constants (libChezSchemePrefix, moduleForeign, moduleLib, rtPrefixed, runtimePrefix, scmPrefixed, undefinedSymbol)
@@ -33,13 +36,14 @@ import Safe.Coerce (coerce)
 
 type CodegenEnv =
   { currentModule :: ModuleName
+  , lazyTopLevelRefs :: Set Ident
   }
 
 codegenModule :: BackendModule -> ChezLibrary
 codegenModule { name, bindings, imports, foreign: foreign_ } =
   let
     codegenEnv :: CodegenEnv
-    codegenEnv = { currentModule: name }
+    codegenEnv = { currentModule: name, lazyTopLevelRefs: Set.empty }
 
     definitions :: Array ChezDefinition
     definitions = Array.concat $
@@ -100,6 +104,7 @@ definitionIdentifiers = case _ of
     [ recordTypeUncurriedConstructor i
     , recordTypePredicate i
     ] <> map (recordTypeAccessor i) fields
+  DefineLazy _ _ _ -> []
 
 flattenQualified :: ModuleName -> Qualified Ident -> String
 flattenQualified _ (Qualified Nothing (Ident i)) = i
@@ -118,8 +123,47 @@ codegenTopLevelBindingGroup
   :: CodegenEnv
   -> BackendBindingGroup Ident NeutralExpr
   -> Array ChezDefinition
-codegenTopLevelBindingGroup codegenEnv { bindings } =
-  Array.concatMap (codegenTopLevelBinding codegenEnv) bindings
+codegenTopLevelBindingGroup codegenEnv { bindings, recursive }
+  | recursive, Just bindings' <- NonEmptyArray.fromArray bindings = do
+      -- Turn non-lazy bindings into lazy bindings so that they can refer to each
+      -- other during initialization. Some definitions are initialized lazily,
+      -- like lambda exressions, so we don't have to touch those.
+      let lazyBindings = NonEmptyArray.partition isLazyBinding bindings'
+      let
+        codegenEnv' = codegenEnv
+          { lazyTopLevelRefs = foldMap (Set.singleton <<< fst) lazyBindings.no }
+      fold
+        [ Array.concatMap (codegenTopLevelBinding codegenEnv') lazyBindings.yes
+        , Array.concatMap (codegenLazyTopLevelBinding codegenEnv') lazyBindings.no
+        , (\(Tuple (Ident ident) _) -> Define ident $ S.forceLazyRef ident) <$> lazyBindings.no
+        ]
+  | otherwise = Array.concatMap (codegenTopLevelBinding codegenEnv) bindings
+
+isLazyBinding :: Tuple Ident NeutralExpr -> Boolean
+isLazyBinding (Tuple _ expr) = case unwrap expr of
+  Abs _ _ ->
+    true
+  UncurriedAbs _ _ ->
+    true
+  UncurriedEffectAbs _ _ ->
+    true
+  CtorDef _ _ _ _ ->
+    true
+  EffectBind _ _ _ _ ->
+    true
+  EffectPure _ ->
+    true
+  EffectDefer _ ->
+    true
+  _ -> false
+
+codegenLazyTopLevelBinding
+  :: CodegenEnv
+  -> Tuple Ident NeutralExpr
+  -> Array ChezDefinition
+codegenLazyTopLevelBinding codegenEnv@{ currentModule } (Tuple (Ident i) n) =
+  case unwrap n of
+    _ -> [ DefineLazy i currentModule $ codegenExpr codegenEnv n ]
 
 codegenTopLevelBinding
   :: CodegenEnv
@@ -149,9 +193,12 @@ codegenTopLevelBinding codegenEnv (Tuple (Ident i) n) =
       [ Define i $ codegenExpr codegenEnv n ]
 
 codegenExpr :: CodegenEnv -> NeutralExpr -> ChezExpr
-codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
+codegenExpr codegenEnv@{ currentModule, lazyTopLevelRefs } s = case unwrap s of
   Var (Qualified (Just (ModuleName "Data.List.Types")) (Ident "Cons")) ->
     S.Identifier (rtPrefixed "list-cons")
+  Var qi@(Qualified (Just moduleName) ident)
+    | moduleName == currentModule && Set.member ident lazyTopLevelRefs ->
+        S.forceLazyRef $ flattenQualified currentModule qi
   Var qi ->
     S.Identifier $ flattenQualified currentModule qi
   Local i l ->

--- a/src/PureScript/Backend/Chez/Printer.purs
+++ b/src/PureScript/Backend/Chez/Printer.purs
@@ -19,7 +19,7 @@ import Data.Tuple (Tuple(..))
 import Dodo (Doc)
 import Dodo as D
 import PureScript.Backend.Chez.Constants (rtPrefixed, scmPrefixed)
-import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezExpr(..), ChezImport(..), ChezImportLevel(..), ChezImportSet(..), ChezLibrary, LibraryBody, LibraryName, LibraryReference, LibraryVersion(..), LiteralDigit(..), SubVersionReference(..), VersionReference(..), recordTypeAccessor, recordTypeCurriedConstructor, recordTypeName, recordTypePredicate, recordTypeUncurriedConstructor)
+import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezExpr(..), ChezImport(..), ChezImportLevel(..), ChezImportSet(..), ChezLibrary, LibraryBody, LibraryName, LibraryReference, LibraryVersion(..), LiteralDigit(..), SubVersionReference(..), VersionReference(..), lazyRefName, recordTypeAccessor, recordTypeCurriedConstructor, recordTypeName, recordTypePredicate, recordTypeUncurriedConstructor)
 import PureScript.Backend.Optimizer.CoreFn (ModuleName(..))
 
 printWrap :: Doc Void -> Doc Void -> Doc Void -> Doc Void
@@ -239,14 +239,14 @@ printDefinition = case _ of
     printNamedIndentedList (D.words [ D.text $ scmPrefixed "define", D.text ident ])
       $ printChezExpr expr
   DefineLazy ident (ModuleName m) expr -> do
-    let identName = Json.stringify $ Json.fromString ident
+    let origIdentName = Json.stringify $ Json.fromString ident
     let moduleName = Json.stringify $ Json.fromString m
     printNamedIndentedList
       ( D.words
           [ D.text $ rtPrefixed "define-lazy"
-          , D.text identName
+          , D.text origIdentName
           , D.text moduleName
-          , D.text ("$lazy-" <> ident)
+          , D.text (lazyRefName ident)
           ]
       )
       $ printChezExpr expr

--- a/src/PureScript/Backend/Chez/Printer.purs
+++ b/src/PureScript/Backend/Chez/Printer.purs
@@ -5,6 +5,7 @@ module PureScript.Backend.Chez.Printer
 import Prelude
 
 import Control.Alternative as Alternative
+import Data.Argonaut as Json
 import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Array.NonEmpty as NEA
@@ -17,8 +18,9 @@ import Data.String as String
 import Data.Tuple (Tuple(..))
 import Dodo (Doc)
 import Dodo as D
-import PureScript.Backend.Chez.Constants (scmPrefixed)
+import PureScript.Backend.Chez.Constants (rtPrefixed, scmPrefixed)
 import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezExpr(..), ChezImport(..), ChezImportLevel(..), ChezImportSet(..), ChezLibrary, LibraryBody, LibraryName, LibraryReference, LibraryVersion(..), LiteralDigit(..), SubVersionReference(..), VersionReference(..), recordTypeAccessor, recordTypeCurriedConstructor, recordTypeName, recordTypePredicate, recordTypeUncurriedConstructor)
+import PureScript.Backend.Optimizer.CoreFn (ModuleName(..))
 
 printWrap :: Doc Void -> Doc Void -> Doc Void -> Doc Void
 printWrap l r x = l <> x <> r
@@ -89,6 +91,7 @@ escapeIdentifiers lib = lib
 
   escapeDefinition = case _ of
     Define i expr -> Define (escapeIdent i) $ escapeExpr expr
+    DefineLazy i moduleName expr -> DefineLazy (escapeIdent i) moduleName $ escapeExpr expr
     DefineRecordType i fields -> DefineRecordType (escapeIdent i) $ map escapeIdent fields
 
   escapeExpr = case _ of
@@ -234,6 +237,18 @@ printDefinition :: ChezDefinition -> Doc Void
 printDefinition = case _ of
   Define ident expr ->
     printNamedIndentedList (D.words [ D.text $ scmPrefixed "define", D.text ident ])
+      $ printChezExpr expr
+  DefineLazy ident (ModuleName m) expr -> do
+    let identName = Json.stringify $ Json.fromString ident
+    let moduleName = Json.stringify $ Json.fromString m
+    printNamedIndentedList
+      ( D.words
+          [ D.text $ rtPrefixed "define-lazy"
+          , D.text identName
+          , D.text moduleName
+          , D.text ("$lazy-" <> ident)
+          ]
+      )
       $ printChezExpr expr
   DefineRecordType ident [ field ] ->
     printRecordDefinition

--- a/src/PureScript/Backend/Chez/Printer.purs
+++ b/src/PureScript/Backend/Chez/Printer.purs
@@ -244,9 +244,9 @@ printDefinition = case _ of
     printNamedIndentedList
       ( D.words
           [ D.text $ rtPrefixed "define-lazy"
+          , D.text (lazyRefName ident)
           , D.text origIdentName
           , D.text moduleName
-          , D.text (lazyRefName ident)
           ]
       )
       $ printChezExpr expr

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -9,9 +9,9 @@ import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
-import Data.Tuple (Tuple(..))
+import Data.Tuple (Tuple)
 import PureScript.Backend.Chez.Constants (rtPrefixed, scmPrefixed)
-import PureScript.Backend.Optimizer.CoreFn (Prop(..))
+import PureScript.Backend.Optimizer.CoreFn (ModuleName(..), Prop(..))
 
 type ChezLibrary =
   { "#!r6rs" :: Boolean
@@ -78,6 +78,7 @@ type LibraryBody =
 data ChezDefinition
   = Define String ChezExpr
   | DefineRecordType String (Array String)
+  | DefineLazy String ModuleName ChezExpr
 
 newtype LiteralDigit = LiteralDigit String
 
@@ -178,3 +179,16 @@ recordUpdate h f = do
         , rest
         ]
   foldr field h f
+
+forceLazyRef :: String -> ChezExpr
+forceLazyRef i = List [ Identifier ("$lazy-" <> i) ]
+
+lazyBinding :: ChezExpr -> ChezExpr
+lazyBinding expr = List
+  [ Identifier (rtPrefixed "lazy")
+  , List
+      [ Identifier (scmPrefixed "lambda")
+      , List []
+      , expr
+      ]
+  ]

--- a/src/PureScript/Backend/Chez/Syntax.purs
+++ b/src/PureScript/Backend/Chez/Syntax.purs
@@ -11,7 +11,7 @@ import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Data.Tuple (Tuple)
 import PureScript.Backend.Chez.Constants (rtPrefixed, scmPrefixed)
-import PureScript.Backend.Optimizer.CoreFn (ModuleName(..), Prop(..))
+import PureScript.Backend.Optimizer.CoreFn (ModuleName, Prop(..))
 
 type ChezLibrary =
   { "#!r6rs" :: Boolean
@@ -181,14 +181,8 @@ recordUpdate h f = do
   foldr field h f
 
 forceLazyRef :: String -> ChezExpr
-forceLazyRef i = List [ Identifier ("$lazy-" <> i) ]
+forceLazyRef i = List [ Identifier $ lazyRefName i ]
 
-lazyBinding :: ChezExpr -> ChezExpr
-lazyBinding expr = List
-  [ Identifier (rtPrefixed "lazy")
-  , List
-      [ Identifier (scmPrefixed "lambda")
-      , List []
-      , expr
-      ]
-  ]
+lazyRefName :: String -> String
+lazyRefName i = "$lazy-" <> i
+

--- a/test-snapshots/src/snapshots-input/Snapshot.Failing.RecursiveBindingGroupLet.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Failing.RecursiveBindingGroupLet.purs
@@ -1,0 +1,23 @@
+module Snapshot.Failing.RecursiveBindingGroupLet where
+
+import Prelude
+import Effect (Effect)
+
+test :: Int
+test = test1.bar
+  where
+  test1 =
+    { foo: (\_ -> test2.baz) unit
+    , bar: (\_ -> test3 42) unit
+    }
+
+  test2 =
+    { baz: (\_ -> test1.bar) unit
+    }
+
+  test3 n
+    | n < 100 = n
+    | otherwise = test1.bar
+
+main :: Effect Unit
+main = pure unit

--- a/test-snapshots/src/snapshots-input/Snapshot.Failing.RecursiveBindingGroupTopLevel.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.Failing.RecursiveBindingGroupTopLevel.purs
@@ -1,0 +1,23 @@
+module Snapshot.Failing.RecursiveBindingGroupTopLevel where
+
+import Prelude
+import Effect (Effect)
+
+test1 :: { bar :: Int, foo :: Int }
+test1 =
+  { foo: (\_ -> test2.baz) unit
+  , bar: (\_ -> test3 42) unit
+  }
+
+test2 :: { baz :: Int }
+test2 =
+  { baz: (\_ -> test1.bar) unit
+  }
+
+test3 :: Int -> Int
+test3 n
+  | n < 100 = n
+  | otherwise = test1.bar
+
+main :: Effect Unit
+main = pure unit

--- a/test-snapshots/src/snapshots-input/Snapshot.RecursiveDefinition.purs
+++ b/test-snapshots/src/snapshots-input/Snapshot.RecursiveDefinition.purs
@@ -1,0 +1,26 @@
+-- This example is from <https://github.com/purescript/purescript/blob/0527e71725257bf16a3c7bd5fce608e856a77dae/tests/purs/optimize/4179.purs>
+module Snapshot.RecursiveDefinition where
+
+import Prelude
+import Effect (Effect)
+
+alpha :: Int -> Int -> Number
+alpha = case _ of
+  0 -> bravo
+  1 -> charlie
+  2 -> \y -> if y > 0 then bravo y else charlie y
+  x -> \y -> delta y x
+
+bravo :: Int -> Number
+bravo = (\_ -> alpha) {} 3
+
+charlie :: Int -> Number
+charlie = (\_ -> alpha) {} 4
+
+delta :: Int -> Int -> Number
+delta =
+  let b = (\_ -> bravo) {}
+  in \x y -> if x == y then b 0 else 1.0
+
+main :: Effect Unit
+main = pure unit

--- a/test-snapshots/src/snapshots-output/Snapshot.Failing.RecursiveBindingGroupLet.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Failing.RecursiveBindingGroupLet.ss
@@ -1,0 +1,25 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Failing.RecursiveBindingGroupLet lib)
+  (export
+    main
+    test)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (purs runtime) rt:)
+    (prefix (Data.Unit lib) Data.Unit.))
+
+  (scm:define test
+    (scm:letrec*
+      ([test30 (scm:lambda (n1)
+        (scm:cond
+          [(scm:fx<? n1 100) n1]
+          [scm:else (rt:record-ref test10 (scm:string->symbol "bar"))]))]
+       [test20 (scm:list (scm:cons (scm:string->symbol "baz") (rt:record-ref test10 (scm:string->symbol "bar"))))]
+       [test10 (scm:list (scm:cons (scm:string->symbol "foo") (rt:record-ref test20 (scm:string->symbol "baz"))) (scm:cons (scm:string->symbol "bar") (test30 42)))])
+        (rt:record-ref test10 (scm:string->symbol "bar"))))
+
+  (scm:define main
+    (scm:lambda ()
+      Data.Unit.unit)))

--- a/test-snapshots/src/snapshots-output/Snapshot.Failing.RecursiveBindingGroupTopLevel.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Failing.RecursiveBindingGroupTopLevel.ss
@@ -18,10 +18,10 @@
         [(scm:fx<? n0 100) n0]
         [scm:else (rt:record-ref ($lazy-test1) (scm:string->symbol "bar"))])))
 
-  (rt:define-lazy "test2" "Snapshot.Failing.RecursiveBindingGroupTopLevel" $lazy-test2
+  (rt:define-lazy $lazy-test2 "test2" "Snapshot.Failing.RecursiveBindingGroupTopLevel"
     (scm:list (scm:cons (scm:string->symbol "baz") (rt:record-ref ($lazy-test1) (scm:string->symbol "bar")))))
 
-  (rt:define-lazy "test1" "Snapshot.Failing.RecursiveBindingGroupTopLevel" $lazy-test1
+  (rt:define-lazy $lazy-test1 "test1" "Snapshot.Failing.RecursiveBindingGroupTopLevel"
     (scm:list (scm:cons (scm:string->symbol "foo") (rt:record-ref ($lazy-test1) (scm:string->symbol "bar"))) (scm:cons (scm:string->symbol "bar") 42)))
 
   (scm:define test2

--- a/test-snapshots/src/snapshots-output/Snapshot.Failing.RecursiveBindingGroupTopLevel.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Failing.RecursiveBindingGroupTopLevel.ss
@@ -1,0 +1,35 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.Failing.RecursiveBindingGroupTopLevel lib)
+  (export
+    main
+    test1
+    test2
+    test3)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (purs runtime) rt:)
+    (prefix (Data.Unit lib) Data.Unit.))
+
+  (scm:define test3
+    (scm:lambda (n0)
+      (scm:cond
+        [(scm:fx<? n0 100) n0]
+        [scm:else (rt:record-ref ($lazy-test1) (scm:string->symbol "bar"))])))
+
+  (rt:define-lazy "test2" "Snapshot.Failing.RecursiveBindingGroupTopLevel" $lazy-test2
+    (scm:list (scm:cons (scm:string->symbol "baz") (rt:record-ref ($lazy-test1) (scm:string->symbol "bar")))))
+
+  (rt:define-lazy "test1" "Snapshot.Failing.RecursiveBindingGroupTopLevel" $lazy-test1
+    (scm:list (scm:cons (scm:string->symbol "foo") (rt:record-ref ($lazy-test1) (scm:string->symbol "bar"))) (scm:cons (scm:string->symbol "bar") 42)))
+
+  (scm:define test2
+    ($lazy-test2))
+
+  (scm:define test1
+    ($lazy-test1))
+
+  (scm:define main
+    (scm:lambda ()
+      Data.Unit.unit)))

--- a/test-snapshots/src/snapshots-output/Snapshot.RecursiveDefinition.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.RecursiveDefinition.ss
@@ -1,0 +1,51 @@
+#!r6rs
+#!chezscheme
+(library
+  (Snapshot.RecursiveDefinition lib)
+  (export
+    alpha
+    bravo
+    charlie
+    delta
+    main)
+  (import
+    (prefix (chezscheme) scm:)
+    (prefix (purs runtime) rt:)
+    (prefix (Data.Unit lib) Data.Unit.))
+
+  (scm:define main
+    (scm:lambda ()
+      Data.Unit.unit))
+
+  (scm:define delta
+    (scm:lambda (x0)
+      (scm:lambda (y1)
+        (scm:cond
+          [(scm:fx=? x0 y1) (($lazy-bravo) 0)]
+          [scm:else 1.0]))))
+
+  (scm:define alpha
+    (scm:lambda (v0)
+      (scm:cond
+        [(scm:fx=? v0 0) ($lazy-bravo)]
+        [(scm:fx=? v0 1) ($lazy-charlie)]
+        [(scm:fx=? v0 2) (scm:lambda (y1)
+          (scm:cond
+            [(scm:fx>? y1 0) (($lazy-bravo) y1)]
+            [scm:else (($lazy-charlie) y1)]))]
+        [scm:else (scm:lambda (y1)
+          (scm:cond
+            [(scm:fx=? y1 v0) (($lazy-bravo) 0)]
+            [scm:else 1.0]))])))
+
+  (rt:define-lazy "charlie" "Snapshot.RecursiveDefinition" $lazy-charlie
+    (alpha 4))
+
+  (rt:define-lazy "bravo" "Snapshot.RecursiveDefinition" $lazy-bravo
+    (alpha 3))
+
+  (scm:define charlie
+    ($lazy-charlie))
+
+  (scm:define bravo
+    ($lazy-bravo)))

--- a/test-snapshots/src/snapshots-output/Snapshot.RecursiveDefinition.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.RecursiveDefinition.ss
@@ -38,10 +38,10 @@
             [(scm:fx=? y1 v0) (($lazy-bravo) 0)]
             [scm:else 1.0]))])))
 
-  (rt:define-lazy "charlie" "Snapshot.RecursiveDefinition" $lazy-charlie
+  (rt:define-lazy $lazy-charlie "charlie" "Snapshot.RecursiveDefinition"
     (alpha 4))
 
-  (rt:define-lazy "bravo" "Snapshot.RecursiveDefinition" $lazy-bravo
+  (rt:define-lazy $lazy-bravo "bravo" "Snapshot.RecursiveDefinition"
     (alpha 3))
 
   (scm:define charlie

--- a/vendor/purs/runtime.ss
+++ b/vendor/purs/runtime.ss
@@ -116,7 +116,8 @@
 
   (define-syntax define-lazy
     (syntax-rules ()
-      [(_ ident module id body ...) (define id (lazy ident module (lambda () body ...)))]))
+      [(_ id ident module body ...)
+        (define id (lazy ident module (lambda () body ...)))]))
 
   (define (lazy ident module f)
     (let ([state 0]
@@ -124,7 +125,7 @@
       (lambda ()
         (cond
           [(eq? state 2) value]
-          [(eq? state 1) (error #f (format "Binding for ~a ~a demanded before initialized" module ident))]
+          [(eq? state 1) (error #f (format "~a was needed before it finished initializing (module ~a)" ident module))]
           [else
             (begin
               (set! state 1)

--- a/vendor/purs/runtime.ss
+++ b/vendor/purs/runtime.ss
@@ -11,6 +11,8 @@
     array-length
     array-ref
     make-array
+    define-lazy
+    lazy
     boolean<?
     boolean<=?
     boolean>=?
@@ -106,6 +108,29 @@
 
   (define list-cons
     (lambda (x) (lambda (xs) (cons x xs))))
+
+
+  ;
+  ; Lazy bindings
+  ;
+
+  (define-syntax define-lazy
+    (syntax-rules ()
+      [(_ ident module id body ...) (define id (lazy ident module (lambda () body ...)))]))
+
+  (define (lazy ident module f)
+    (let ([state 0]
+          [value #f])
+      (lambda ()
+        (cond
+          [(eq? state 2) value]
+          [(eq? state 1) (error #f (format "Binding for ~a ~a demanded before initialized" module ident))]
+          [else
+            (begin
+              (set! state 1)
+              (set! value (f))
+              (set! state 2)
+              value)]))))
 
 
   )


### PR DESCRIPTION
Implements lazy initialization for top-level recursive bindings. This allows mutually recursive top-level definitions to refer to each other during initialization. It also provides a better runtime error in the case that a definition is referring to itself during initialization. These rarely happen in the wild, especially since we use the optimizer that sometimes inlines away these recursive references. However, if you prevent inlining these happen more often. You can read more about lazy initialization [here](https://github.com/purescript/purescript/blob/0527e71725257bf16a3c7bd5fce608e856a77dae/CHANGELOG.d/breaking_fix-4179.md).

This does _not_ implement lazy initialization for non-top-level bindings. I'd like to do this in a separate PR. And note that the Scheme syntax `letrec*` does not allow mutually recursive references during initialization. Same goes for `define`.

### Implementation

There is a new field `lazyTopLevelRefs` that is a `Set` of names that should be initialized lazily. These value is populated for each recursive binding group and then during codegen we lookup all the qualified top-level-names from there, and if found we generate a lazy reference.

A lazy binding is a thunk, that when called will initialize the binding and keep track of self-references to provide an error message. Lazy definitions are implemented as a new special form in the runtime called `define-lazy` just to prevent noise in the output caused by the thunks.

We could use the normal `Define` constructor for the lazy definitions but then we would need to add a boolean flag to `Define` to indicate whether the binding should be exported or not (lazy bindings don't need to be exported), or we could export even the lazy bindings. I thought that a new `DefineLazy` would be the cleanest and would allow using the `define-lazy` special form more easily. That being said, I'm not convinced that generating macro forms is always a good idea, here it feels ok.

The test suite now also supports tests that fail at runtime by a test naming convention. It doesn't check the failure reason. At some point we refactored the test suite to use the production builder which makes it difficult to hook into the tests such that we could for example annotate the test source file with the failure reason. We should look into this later.
