### PR TITLE
Use the same symbol for `PrimUndefined`

### DIFF
--- a/src/PureScript/Backend/Chez/Constants.purs
+++ b/src/PureScript/Backend/Chez/Constants.purs
@@ -22,6 +22,3 @@ moduleLib = "lib"
 
 schemeExt :: String
 schemeExt = ".ss"
-
-undefinedSymbol :: String
-undefinedSymbol = "purs-undefined"

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -22,7 +22,7 @@ import Data.String.Regex.Unsafe as R.Unsafe
 import Data.Tuple (Tuple(..), uncurry)
 import Data.Tuple as Tuple
 import Partial.Unsafe (unsafeCrashWith)
-import PureScript.Backend.Chez.Constants (libChezSchemePrefix, moduleForeign, moduleLib, rtPrefixed, runtimePrefix, scmPrefixed, undefinedSymbol)
+import PureScript.Backend.Chez.Constants (libChezSchemePrefix, moduleForeign, moduleLib, rtPrefixed, runtimePrefix, scmPrefixed)
 import PureScript.Backend.Chez.Syntax (ChezDefinition(..), ChezExport(..), ChezExpr, ChezImport(..), ChezImportSet(..), ChezLibrary, recordTypeAccessor, recordTypeCurriedConstructor, recordTypePredicate, recordTypeUncurriedConstructor)
 import PureScript.Backend.Chez.Syntax as S
 import PureScript.Backend.Optimizer.Convert (BackendModule, BackendBindingGroup)
@@ -234,7 +234,7 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
 
   PrimOp o ->
     codegenPrimOp codegenEnv o
-  PrimUndefined -> S.quote $ S.Identifier undefinedSymbol
+  PrimUndefined -> S.quote $ S.Identifier "undefined"
 
   Fail i ->
     -- Note: This can be improved by using `error`, but it requires

--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -234,9 +234,7 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
 
   PrimOp o ->
     codegenPrimOp codegenEnv o
-  PrimUndefined ->
-    S.app (S.Identifier $ scmPrefixed "gensym")
-      (S.StringExpr $ Json.stringify $ Json.fromString undefinedSymbol)
+  PrimUndefined -> S.quote $ S.Identifier undefinedSymbol
 
   Fail i ->
     -- Note: This can be improved by using `error`, but it requires

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -20,7 +20,7 @@
 
   (scm:define insert
     (((Record.insert (scm:list (scm:cons (scm:string->symbol "reflectSymbol") (scm:lambda (_)
-      (rt:string->pstring "anotherField"))))) (scm:gensym "purs-undefined")) (scm:gensym "purs-undefined")))
+      (rt:string->pstring "anotherField"))))) (scm:quote purs-undefined)) (scm:quote purs-undefined)))
 
   (scm:define recordUpdate
     (scm:lambda (v0)
@@ -38,7 +38,7 @@
     (scm:let*
       ([r0 (scm:list (scm:cons (scm:string->symbol "fooBarBaz") 5))]
        [s1 (recordUpdate r0)]
-       [t2 ((recordAddField (scm:gensym "purs-undefined")) s1)]
+       [t2 ((recordAddField (scm:quote purs-undefined)) s1)]
        [u3 (scm:list (scm:cons (scm:string->symbol "fooBarBaz") minusTwo))]
        [_4 (Test.Assert.assert (scm:fx=? (recordAccess t2) 10))])
         (scm:lambda ()

--- a/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Literals.Record.ss
@@ -20,7 +20,7 @@
 
   (scm:define insert
     (((Record.insert (scm:list (scm:cons (scm:string->symbol "reflectSymbol") (scm:lambda (_)
-      (rt:string->pstring "anotherField"))))) (scm:quote purs-undefined)) (scm:quote purs-undefined)))
+      (rt:string->pstring "anotherField"))))) (scm:quote undefined)) (scm:quote undefined)))
 
   (scm:define recordUpdate
     (scm:lambda (v0)
@@ -38,7 +38,7 @@
     (scm:let*
       ([r0 (scm:list (scm:cons (scm:string->symbol "fooBarBaz") 5))]
        [s1 (recordUpdate r0)]
-       [t2 ((recordAddField (scm:quote purs-undefined)) s1)]
+       [t2 ((recordAddField (scm:quote undefined)) s1)]
        [u3 (scm:list (scm:cons (scm:string->symbol "fooBarBaz") minusTwo))]
        [_4 (Test.Assert.assert (scm:fx=? (recordAccess t2) 10))])
         (scm:lambda ()

--- a/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
@@ -13,7 +13,7 @@
 
   (scm:define testCase
     (scm:lambda (dictRing0)
-      (rt:record-ref ((rt:record-ref dictRing0 (scm:string->symbol "Semiring0")) (scm:gensym "purs-undefined")) (scm:string->symbol "add"))))
+      (rt:record-ref ((rt:record-ref dictRing0 (scm:string->symbol "Semiring0")) (scm:quote purs-undefined)) (scm:string->symbol "add"))))
 
   (scm:define main
     (Test.Assert.assert (scm:fx=? (((testCase Data.Ring.ringInt) 1) 1) 2))))

--- a/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.PrimUndefined.ss
@@ -13,7 +13,7 @@
 
   (scm:define testCase
     (scm:lambda (dictRing0)
-      (rt:record-ref ((rt:record-ref dictRing0 (scm:string->symbol "Semiring0")) (scm:quote purs-undefined)) (scm:string->symbol "add"))))
+      (rt:record-ref ((rt:record-ref dictRing0 (scm:string->symbol "Semiring0")) (scm:quote undefined)) (scm:string->symbol "add"))))
 
   (scm:define main
     (Test.Assert.assert (scm:fx=? (((testCase Data.Ring.ringInt) 1) 1) 2))))


### PR DESCRIPTION
We generated a new symbol each time using `gensym`, but I don't think it's necessary. Now just using `'purs-undefined`.