### PR TITLE
Use a special runtime function for failed pattern match

### DIFF
--- a/src/PureScript/Backend/Chez/Convert.purs
+++ b/src/PureScript/Backend/Chez/Convert.purs
@@ -238,21 +238,13 @@ codegenExpr codegenEnv@{ currentModule } s = case unwrap s of
     S.app (S.Identifier $ scmPrefixed "gensym")
       (S.StringExpr $ Json.stringify $ Json.fromString undefinedSymbol)
 
-  Fail i ->
+  Fail "Failed pattern match" ->
     -- Note: This can be improved by using `error`, but it requires
     -- that we track where exactly this `Fail` is defined. We can
     -- make use of the `codegenEnv` for this.
-    S.List
-      [ S.Identifier $ scmPrefixed "raise"
-      , S.List
-          [ S.Identifier $ scmPrefixed "condition"
-          , S.List [ S.Identifier $ scmPrefixed "make-error" ]
-          , S.List
-              [ S.Identifier $ scmPrefixed "make-message-condition"
-              , S.StringExpr $ Json.stringify $ Json.fromString i
-              ]
-          ]
-      ]
+    S.List [ S.Identifier $ rtPrefixed "fail" ]
+  Fail _ ->
+    unsafeCrashWith "Unsupported fail."
 
 codegenLiteral :: CodegenEnv -> Literal NeutralExpr -> ChezExpr
 codegenLiteral codegenEnv = case _ of

--- a/test-snapshots/src/snapshots-output/Snapshot.Branch.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Branch.ss
@@ -18,13 +18,13 @@
           [v0 (scm:not v11)]
           [(scm:not v11) #t]
           [v11 #f]
-          [scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))]))))
+          [scm:else (rt:fail)]))))
 
   (scm:define h
     (scm:lambda (v0)
       (scm:cond
         [(scm:fl=? v0 3.14) 3.14159]
-        [scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))])))
+        [scm:else (rt:fail)])))
 
   (scm:define g
     (scm:lambda (v0)

--- a/test-snapshots/src/snapshots-output/Snapshot.ConstructorAccessor.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.ConstructorAccessor.ss
@@ -88,14 +88,14 @@
       (scm:lambda (v1)
         (scm:cond
           [(First? v1) (First-value0 v1)]
-          [scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))]))))
+          [scm:else (rt:fail)]))))
 
   (scm:define test5
     (scm:lambda (v0)
       (scm:cond
         [(First? v0) (First-value0 v0)]
         [(Last? v0) (Last-value0 v0)]
-        [scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))])))
+        [scm:else (rt:fail)])))
 
   (scm:define test4
     (scm:lambda (v0)

--- a/test-snapshots/src/snapshots-output/Snapshot.List.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.List.ss
@@ -35,14 +35,14 @@
       (scm:cond
         [(scm:null? v0) Data.Maybe.Nothing]
         [(scm:pair? v0) (Data.Maybe.Just (scm:cdr v0))]
-        [scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))])))
+        [scm:else (rt:fail)])))
 
   (scm:define car
     (scm:lambda (v0)
       (scm:cond
         [(scm:null? v0) Data.Maybe.Nothing]
         [(scm:pair? v0) (Data.Maybe.Just (scm:car v0))]
-        [scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))])))
+        [scm:else (rt:fail)])))
 
   (scm:define main
     (scm:let ([_0 (Test.Assert.assert #t)])

--- a/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
+++ b/test-snapshots/src/snapshots-output/Snapshot.Prime.ss
@@ -108,7 +108,7 @@
       (scm:cond
         [(F1? v0) (rt:string->pstring "F1")]
         [(F2? v0) (rt:string->pstring "F2")]
-        [scm:else (scm:raise (scm:condition (scm:make-error) (scm:make-message-condition "Failed pattern match")))])))))
+        [scm:else (rt:fail)])))))
 
   (scm:define useInstance
     (rt:string->pstring "F1F2"))

--- a/vendor/purs/runtime.ss
+++ b/vendor/purs/runtime.ss
@@ -21,7 +21,8 @@
     pstring>?
     pstring>=?
     pstring<?
-    pstring<=?)
+    pstring<=?
+    fail)
   (import
     (chezscheme)
     (only (purs runtime pstring) string->pstring
@@ -106,6 +107,13 @@
 
   (define list-cons
     (lambda (x) (lambda (xs) (cons x xs))))
+
+
+  (define (fail)
+    (raise
+      (condition
+        (make-error)
+        (make-message-condition "Failed pattern match"))))
 
 
   )

--- a/vendor/purs/runtime.ss
+++ b/vendor/purs/runtime.ss
@@ -140,7 +140,7 @@
   ;
 
   (define (fail)
-    (raise
+    (raise-continuable
       (condition
         (make-error)
         (make-message-condition "Failed pattern match"))))

--- a/vendor/purs/runtime.ss
+++ b/vendor/purs/runtime.ss
@@ -109,6 +109,10 @@
     (lambda (x) (lambda (xs) (cons x xs))))
 
 
+  ;
+  ; Runtime failures
+  ;
+
   (define (fail)
     (raise
       (condition


### PR DESCRIPTION
There are no other failure cases than the failed pattern match case, so instead of handling arbitrary error strings we just use a special runtime function for failed pattern matches. This also cleans up the output nicely.

This is part of a series of refactorings I'm doing to use `StringExpr` only for strings that actually need to be escaped. Then we can have the string escaping only in one place.